### PR TITLE
Differential Attestation reports generation

### DIFF
--- a/kernel/src/attestation/monitor.rs
+++ b/kernel/src/attestation/monitor.rs
@@ -222,7 +222,7 @@ fn trustlet_report(params: &mut RequestParams) -> Result<(), SvsmReqError>{
 
     // Now new_report holds the existing report data + measurements
     let new_report_size = new_report.len();
-    log::info!{"zygote report size: { } original size: { }", new_report_size, REPORT_RESPONSE_SIZE};
+
     // Perform the copy_back_report with the new cumulative report
     copy_back_report(params.rcx, &new_report, new_report_size);
     return Ok(());
@@ -281,7 +281,7 @@ fn function_report(params: &mut RequestParams) -> Result<(), SvsmReqError>{
 
     // Now new_report holds the existing report data + measurements
     let new_report_size = new_report.len();
-    log::info!{"function report size: { }", new_report_size};
+
     // Perform the copy_back_report with the new cumulative report
     copy_back_report(params.rcx, &new_report, new_report_size);
     return Ok(());

--- a/kernel/src/attestation/monitor.rs
+++ b/kernel/src/attestation/monitor.rs
@@ -44,7 +44,7 @@ const HASH_SIZE: usize = 64;
 const KEY_SIZE: usize = 32;
 const NONCE_SIZE: usize = 24;
 
-const MONITOR_ATTESTATION: u64 = 0;
+pub const MONITOR_ATTESTATION: u64 = 0;
 const ZYGOTE_ATTESTATION: u64 = 1;
 const TRUSTLET_ATTESTATION: u64 = 2;
 const FUNCTION_ATTESTATION: u64 = 3;
@@ -140,7 +140,7 @@ fn monitor_report(params: &mut RequestParams) -> Result<(), SvsmReqError> {
 
         let report_size = snp_response.get_report_size() as usize;
         let report = snp_response.get_report();
-        log::info!("actual report size { }", snp_response.get_report_size());
+        log::debug!("actual report size { }", snp_response.get_report_size());
 
         let report_bytes = unsafe {
           core::slice::from_raw_parts(
@@ -151,8 +151,11 @@ fn monitor_report(params: &mut RequestParams) -> Result<(), SvsmReqError> {
 
         // Store the report and its size
         store_snp_report(report_bytes, report_size);
-        // Return the report
-        copy_back_report(params.rcx, report_bytes, report_size);
+
+        // Return the report (if requested)
+        if params.rdx != 0 {
+          copy_back_report(params.rcx, report_bytes, report_size);
+        }
     }
     Ok(())
 }

--- a/kernel/src/attestation/monitor.rs
+++ b/kernel/src/attestation/monitor.rs
@@ -4,37 +4,97 @@ use crate::protocols::errors::SvsmReqError;
 use crate::protocols::RequestParams;
 use crate::mm::PerCPUPageMappingGuard;
 use core::slice;
+use crate::vaddr_as_u64_slice;
 
 use crate::my_crypto_wrapper::my_SHA512;
 use crate::my_crypto_wrapper::get_keys;
 use crate::my_crypto_wrapper::decrypt;
 use crate::my_crypto_wrapper::key_pair;
 
+use crate::process_manager::PROCESS_STORE;
+use crate::process_manager::process::ProcessID;
+use crate::process_manager::process_paging::ProcessPageTableRef;
+use crate::mm::PAGE_SIZE;
+
+const HASH_SIZE: usize = 64;
+const KEY_SIZE: usize = 32;
+const NONCE_SIZE: usize = 24;
+
+const MONITOR_ATTESTATION: u64 = 0;
+const ZYGOTE_ATTESTATION: u64 = 1;
+const TRUSTLET_ATTESTATION: u64 = 2;
+const FUNCTION_ATTESTATION: u64 = 3;
+
+#[repr(C, packed)]
+struct FunctionData {
+    trustlet_id: u64,
+    fn_input_size: u64,
+    fn_input_addr: usize,
+    fn_output_size: u64,
+    fn_output_addr: usize,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct ProcessMeasurements {
+    pub init_measurement: [u8; 64],
+    pub manifest_measurement: [u8; 64],
+    pub libos_measurement: [u8; 64],
+}
+
+impl Default for ProcessMeasurements {
+    fn default() -> Self {
+        return ProcessMeasurements {
+            init_measurement: [0; HASH_SIZE],
+            manifest_measurement: [0; HASH_SIZE],
+            libos_measurement: [0; HASH_SIZE],
+        }
+    }
+}
 
 #[allow(non_snake_case)]
-pub fn attest_monitor(params: &mut RequestParams) -> Result<(), SvsmReqError>{
-   // log::info!("[Doing attest]");
-    let mut rep: [u8; REPORT_RESPONSE_SIZE] = [0u8;REPORT_RESPONSE_SIZE];
+pub fn measure(start_address: u64, size: u64) -> [u8; HASH_SIZE] {
+
+    // Unsafe part: ensure the memory region is accessible and valid
+    let region = unsafe {
+        core::slice::from_raw_parts(start_address as *const u8, size as usize)
+    };
+    log::debug!("[Measure] Region address {:p} and len { }", region, region.len());
+
+    let mut hash: [u8; HASH_SIZE] = [0; HASH_SIZE];
+    // Get the hash using SHA-512 over the entire memory region
+    unsafe {
+        my_SHA512(
+            region.as_ptr() as *mut u8,
+            region.len().try_into().unwrap(),
+            hash.as_mut_ptr(),
+        );
+    }
+
+    // Return the final hash measurement
+    hash
+}
+
+#[allow(non_snake_case)]
+fn monitor_report(params: &mut RequestParams) -> Result<(), SvsmReqError>{
+    return Ok(());
+    // Original SNP report buffer
+    let mut rep: [u8; REPORT_RESPONSE_SIZE] = [0; REPORT_RESPONSE_SIZE];
 
     // TODO: Change VMPL level before writing hash s.t. guest can't tamper with it
-    let mut pub_key: [u8;32] = unsafe{(*get_keys()).public_key};
+    let mut pub_key: [u8; 32] = unsafe{(*get_keys()).public_key};
     let mut hash: [u8; 64] = [0; 64];
     let _n: i32 = unsafe{my_SHA512(pub_key.as_mut_ptr(), pub_key.len().try_into().unwrap(), hash.as_mut_ptr()).try_into().unwrap()};
- //   log::info!("Raw key: {:?}", pub_key);
- //   log::info!("SHA returned: {} and a hash of {:?}", n, hash);
 
     // Include hash in report
     let mut i = 0;
-    while i < 64 {
+    while i < HASH_SIZE {
         rep[i] = hash[i];
         i += 1;
     }
 
-    //log::info!("Requesting Monitor Attestation Report");
-    //let rep_size = get_regular_report(&mut rep)?;
     let rep_size = match get_regular_report(&mut rep) {
-    Ok(e) => e,
-    Err(e) => {log::info!("Error from get report: {:?}", e); panic!(); }
+        Ok(e) => e,
+        Err(e) => {log::info!("Error from get report: {:?}", e); panic!(); }
     };
 
     if params.rdx == 0 {
@@ -45,17 +105,104 @@ pub fn attest_monitor(params: &mut RequestParams) -> Result<(), SvsmReqError>{
 
     params.rdx = rep_size.try_into().unwrap();
 
-    //log::info!("Size of Report: {rep_size}");
     let _r = SnpReportResponse::try_from_as_ref(&mut rep)?;
-    //log::info!("Report r: {:?}\n",r);
-    //log::info!("Report rep: {:?}\n",rep);
-    //TODO: Check if address is valid for this request
+
     let target_address = PhysAddr::from(params.rcx);
     let mapped_target_page = PerCPUPageMappingGuard::create_4k(target_address).unwrap();
-    let target = unsafe {mapped_target_page.virt_addr().as_mut_ptr::<[u8;4096]>().as_mut().unwrap()};
+    let target = unsafe {mapped_target_page.virt_addr().as_mut_ptr::<[u8;PAGE_SIZE]>().as_mut().unwrap()};
     target[0..rep_size].copy_from_slice(&rep);
-    
-    Ok(())
+}
+
+#[allow(non_snake_case)]
+fn zygote_report(params: &mut RequestParams) -> Result<(), SvsmReqError>{
+    let zygote_id = ProcessID(params.r8 as usize);
+    let zygote = PROCESS_STORE.get(zygote_id);
+
+    let init_measurement = zygote.measurements.init_measurement;
+    let manifest_measurement = zygote.measurements.manifest_measurement;
+    let libos_measurement = zygote.measurements.libos_measurement;
+    // let mut i = 0;
+    // while i < HASH_SIZE {
+    //     log::info!("{:02x} | {:02x} | {:02x}", init_measurement[i], manifest_measurement[i], libos_measurement[i]);
+    //     i += 1;
+    // }
+
+    return Ok(());
+}
+
+#[allow(non_snake_case)]
+fn trustlet_report(params: &mut RequestParams) -> Result<(), SvsmReqError>{
+    let trustlet_id = ProcessID(params.r8 as usize);
+    let trustlet = PROCESS_STORE.get(trustlet_id);
+
+    let init_measurement = trustlet.measurements.init_measurement;
+    let manifest_measurement = trustlet.measurements.manifest_measurement;
+    let libos_measurement = trustlet.measurements.libos_measurement;
+    // let mut i = 0;
+    // while i < HASH_SIZE {
+    //   log::info!("{:02x} | {:02x} | {:02x}", init_measurement[i], manifest_measurement[i], libos_measurement[i]);
+    //   i += 1;
+    // }
+
+    return Ok(());
+}
+
+#[allow(non_snake_case)]
+fn function_report(params: &mut RequestParams) -> Result<(), SvsmReqError>{
+    let guest_pgt = params.r8;
+    let size = PAGE_SIZE;
+    let function_data_addr = params.r9;
+    let (function_data, _) = ProcessPageTableRef::copy_data_from_guest(function_data_addr, (size).try_into().unwrap(), guest_pgt);
+
+    // Extract the parameters from the struct
+    let function_data_struct = vaddr_as_u64_slice!(function_data);
+    let trustlet_id = function_data_struct[0];
+    let fn_input_size = function_data_struct[1];
+    let fn_input_addr = function_data_struct[2];
+    let fn_output_size = function_data_struct[3];
+    let fn_output_addr = function_data_struct[4];
+    log::debug!("Extracted values { } { } { } { } { }", trustlet_id, fn_input_size, fn_input_addr, fn_output_size, fn_output_addr);
+
+    // Get the parent process of the function
+    let trustlet_id = ProcessID(trustlet_id as usize);
+    let trustlet = PROCESS_STORE.get(trustlet_id);
+
+    // Get and measure the input data of the function
+    let (input_data, _) = ProcessPageTableRef::copy_data_from_guest(fn_input_addr, fn_input_size, guest_pgt);
+    let input_hash = measure(input_data.into(), fn_input_size);
+
+    // Get and measure the output data of the function
+    let (output_data, _) = ProcessPageTableRef::copy_data_from_guest(fn_output_addr, fn_output_size, guest_pgt);
+    let output_hash = measure(output_data.into(), fn_output_size);
+
+    // produce_differential_report(trustlet, input_hash, output_hash);
+    return Ok(());
+}
+
+#[allow(non_snake_case)]
+pub fn diff_attestation(params: &mut RequestParams) -> Result<(), SvsmReqError>{
+    match params.rdx {
+        MONITOR_ATTESTATION => {
+            log::info!("[Performing monitor attestation]");
+            let _ = monitor_report(params);
+        }
+        ZYGOTE_ATTESTATION => {
+            log::info!("[Performing zygote {} attestation]", params.r8);
+            let _ = zygote_report(params);
+        }
+        TRUSTLET_ATTESTATION => {
+            log::info!("[Performing trustlet {} attestation]", params.r8);
+            let _ = trustlet_report(params);
+        }
+        FUNCTION_ATTESTATION => {
+            log::info!("[Performing function attestation]");
+            let _ = function_report(params);
+        }
+        _ => {
+            log::info!("[Unknown attestation request type]");
+        }
+    }
+    return Ok(());
 }
 
 #[allow(non_snake_case)]
@@ -67,20 +214,20 @@ pub fn get_public_key(params: &mut RequestParams) -> Result<(), SvsmReqError> {
 
     let target_address = PhysAddr::from(params.rcx);
     let mapped_target_page = PerCPUPageMappingGuard::create_4k(target_address).unwrap();
-    let target = unsafe {mapped_target_page.virt_addr().as_mut_ptr::<[u8;4096]>().as_mut().unwrap()};
+    let target = unsafe {mapped_target_page.virt_addr().as_mut_ptr::<[u8;PAGE_SIZE]>().as_mut().unwrap()};
 
     let mut i: usize = 0;
-    while i < 32 {
+    while i < KEY_SIZE {
         target[i] = encryption_keys.public_key[i];
         i = i + 1;
     }   
-    target[32] = 0;
+    target[KEY_SIZE] = 0;
    
   Ok(())  
 }
 
 pub fn exec_elf(params: &mut RequestParams) -> Result<(), SvsmReqError> {
-    //TODO: Get the PA of the 2 pages, copy contents 2 contiguous array.
+    // TODO: Get the PA of the 2 pages, copy contents 2 contiguous array.
     // Use the ELF read functions on the array and inspect the results
     // See how to execute the ELF. Modify a register and read it from monitor to verify program
     // execution
@@ -88,23 +235,23 @@ pub fn exec_elf(params: &mut RequestParams) -> Result<(), SvsmReqError> {
     log::info!("Monitor received elf");
     let page1_address = PhysAddr::from(params.r8);
     let page1 = PerCPUPageMappingGuard::create_4k(page1_address).unwrap();
-    let page1_data = unsafe {page1.virt_addr().as_mut_ptr::<[u8;4096]>().as_mut().unwrap()};
+    let page1_data = unsafe {page1.virt_addr().as_mut_ptr::<[u8;PAGE_SIZE]>().as_mut().unwrap()};
 
     let page2_address = PhysAddr::from(params.rcx);
     let page2 = PerCPUPageMappingGuard::create_4k(page2_address).unwrap();
-    let page2_data = unsafe {page2.virt_addr().as_mut_ptr::<[u8;4096]>().as_mut().unwrap()};
+    let page2_data = unsafe {page2.virt_addr().as_mut_ptr::<[u8;PAGE_SIZE]>().as_mut().unwrap()};
 
     let elf_size : u32 = params.rdx.try_into().unwrap();
 
     log::info!("[Monitor] Elf size: {}", elf_size);
 
     //copy elf in contiguous array
-    let mut elf_raw_data : [u8; 4096 * 2] = [0; 4096 * 2];
+    let mut elf_raw_data : [u8; PAGE_SIZE * 2] = [0; PAGE_SIZE * 2];
 
     let mut i = 0;
-    while i < 4096 {
+    while i < PAGE_SIZE {
         elf_raw_data[i] = page1_data[i];
-        elf_raw_data[i + 4096] = page2_data[i];
+        elf_raw_data[i + PAGE_SIZE] = page2_data[i];
         i = i + 1;
     }
 
@@ -113,9 +260,7 @@ pub fn exec_elf(params: &mut RequestParams) -> Result<(), SvsmReqError> {
         Ok(elf) => elf,
         Err(e) => panic!("error reading ELF: {}", e),
     };
-
     log::info!("Elf file: {:?}", elf);
-
     Ok(())
 }
 
@@ -124,23 +269,18 @@ pub fn send_policy(params: &mut RequestParams) -> Result<(), SvsmReqError> {
     log::info!("[Monitor] Receiveing policy");
     let encrypted_data_address = PhysAddr::from(params.r8);
     let mapped_enc_data_page = PerCPUPageMappingGuard::create_4k(encrypted_data_address).unwrap();
-    let encrypted_data = unsafe {mapped_enc_data_page.virt_addr().as_mut_ptr::<[u8;4096]>().as_mut().unwrap()};
+    let encrypted_data = unsafe {mapped_enc_data_page.virt_addr().as_mut_ptr::<[u8;PAGE_SIZE]>().as_mut().unwrap()};
 
     let sender_pub_key_address = PhysAddr::from(params.rcx);
     let mapped_sender_pub_key_page = PerCPUPageMappingGuard::create_4k(sender_pub_key_address).unwrap();
     let sender_pub_key = unsafe {mapped_sender_pub_key_page.virt_addr().as_mut_ptr::<[u8;32]>().as_mut().unwrap()};
 
     let encrypted_data_size: u32 = params.rdx.try_into().unwrap();
-    let mut decrypted: [u8; 4096] = [0; 4096];
+    let mut decrypted: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
 
-    let mut nonce: [u8; 24] = [0; 24];
-//    let initial_time = unsafe{get_cycles()};
-    let _n: u32 = unsafe{decrypt(decrypted.as_mut_ptr(), encrypted_data.as_mut_ptr(), encrypted_data_size , nonce.as_mut_ptr(), sender_pub_key.as_mut_ptr(), (*get_keys()).private_key.as_mut_ptr())};
- //   let final_time = unsafe{get_cycles()};
-    //log::info!("Total cycles for decryption: {}", final_time - initial_time);
-    //log::info!("Sender pub key: {:?}", sender_pub_key);
-    //log::info!("Encrypted data: {:?}", encrypted_data);
-    //log::info!("Decryption:{} Bytes: {:?}", n, decrypted);
-
+    let mut nonce: [u8; NONCE_SIZE] = [0; NONCE_SIZE];
+    let _n: u32 = unsafe{decrypt(decrypted.as_mut_ptr(), encrypted_data.as_mut_ptr(),
+                                encrypted_data_size , nonce.as_mut_ptr(),
+                                sender_pub_key.as_mut_ptr(), (*get_keys()).private_key.as_mut_ptr())};
     Ok(())
 }

--- a/kernel/src/greq/pld_report.rs
+++ b/kernel/src/greq/pld_report.rs
@@ -111,6 +111,14 @@ impl SnpReportResponse {
 
         Ok(())
     }
+
+    pub fn get_report(&self) -> &AttestationReport {
+          &self.report
+    }
+
+    pub fn get_report_size(&self) -> u32 {
+          self.report_size
+    }
 }
 
 /// The `TCB_VERSION` contains the security version numbers of each

--- a/kernel/src/process_manager/allocation.rs
+++ b/kernel/src/process_manager/allocation.rs
@@ -3,6 +3,7 @@ use crate::mm::PAGE_SIZE;
 use crate::address::{Address, VirtAddr};
 use crate::process_manager::process_paging::ProcessPageTableRef;
 use crate::process_manager::process_paging::ProcessPageFlags;
+use super::process_memory::{ALLOCATION_RANGE_VIRT_START, PGD};
 use crate::cpu::control_regs::read_cr3;
 use crate::{paddr_as_slice, map_paddr, vaddr_as_slice};
 use crate::mm::PerCPUPageMappingGuard;
@@ -14,13 +15,16 @@ pub struct AllocationRange(pub u64, pub u64);
  impl AllocationRange {
 
     pub fn allocate(&mut self, pages: u64){
+        // Allocates a new memory range for the Monitor
+
+        // Currently the start virtual address is fixed to ALLOCATION_RANGE_VIRT_START
+        let start_address = VirtAddr::from(ALLOCATION_RANGE_VIRT_START);
+
         // Reuses the Process page managment to add new memory to the Monitor
         let mut page_table_ref = ProcessPageTableRef::default();
         page_table_ref.set_external_table(read_cr3().bits() as u64);
         let table_flags = ProcessPageFlags::PRESENT | ProcessPageFlags::WRITABLE |
                           ProcessPageFlags::DIRTY | ProcessPageFlags::ACCESSED;
-
-        let start_address = VirtAddr::from(0x30000000000u64);
 
         for i in 0..(pages as usize) {
             let current_page = allocate_page();
@@ -28,7 +32,8 @@ pub struct AllocationRange(pub u64, pub u64);
         };
 
         let (_mapping, pgd) = paddr_as_slice!(read_cr3());
-        self.0 = pgd[6];
+        let pgd_index = start_address.to_pgtbl_idx::<PGD>();
+        self.0 = pgd[pgd_index];
         self.1 = pages;
 
     }

--- a/kernel/src/process_manager/call_handler.rs
+++ b/kernel/src/process_manager/call_handler.rs
@@ -4,8 +4,9 @@ use crate::attestation;
 use crate::process_manager::process::TrustedProcessType;
 
 const MONITOR_INIT: u32 = 0;
-const ATTEST_MONITOR: u32 = 1;
-//const LOAD_POLICY: u32 = 2;
+// const MONITOR: u32 = 1;
+const DIFF_ATTEST: u32 = 2;
+//const LOAD_POLICY: u32 = 3;
 const CREATE_ZYGOTE: u32 = 4;
 const DELETE_ZYGOTE: u32 = 5;
 const CREATE_TRUSTLET: u32 = 6;
@@ -14,8 +15,8 @@ const INVOKE_TRUSTLET: u32 = 8;
 
 const GET_PUBLIC_KEY: u32 = 30;
 const SEND_POLICY: u32 = 31;
-pub fn attest_monitor(params: &mut RequestParams) -> Result<(), SvsmReqError>{
-    attestation::monitor::attest_monitor(params)
+pub fn diff_attestation(params: &mut RequestParams) -> Result<(), SvsmReqError>{
+    attestation::monitor::diff_attestation(params)
 }
 
 fn monitor_init(_params: &mut RequestParams) -> Result<(), SvsmReqError>{
@@ -60,7 +61,7 @@ pub fn monitor_call_handler(request: u32, params: &mut RequestParams) -> Result<
     log::info!("request: {}",request);
     match request {
         MONITOR_INIT => monitor_init(params),
-        ATTEST_MONITOR => attest_monitor(params),
+        DIFF_ATTEST => diff_attestation(params),
         CREATE_ZYGOTE => create_zygote(params),
         DELETE_ZYGOTE => delete_zygote(params),
         CREATE_TRUSTLET => create_trustlet(params),

--- a/kernel/src/process_manager/call_handler.rs
+++ b/kernel/src/process_manager/call_handler.rs
@@ -15,16 +15,22 @@ const INVOKE_TRUSTLET: u32 = 8;
 
 const GET_PUBLIC_KEY: u32 = 30;
 const SEND_POLICY: u32 = 31;
+
 pub fn diff_attestation(params: &mut RequestParams) -> Result<(), SvsmReqError>{
     attestation::monitor::diff_attestation(params)
 }
 
-fn monitor_init(_params: &mut RequestParams) -> Result<(), SvsmReqError>{
+fn monitor_init(params: &mut RequestParams) -> Result<(), SvsmReqError>{
 
     log::info!("Initilization Monitor");
+
+    /* Request a monitor measurement upon initialization */
+    params.rdx = attestation::monitor::MONITOR_ATTESTATION;
+    params.rcx = 0;
+    let _ = attestation::monitor::diff_attestation(params);
     //add_monitor_memory();
     //super::process::PROCESS_STORE.init(10);
-//    crate::sp_pagetable::set_ecryption_mask_address_size();
+    //crate::sp_pagetable::set_ecryption_mask_address_size();
     log::info!("Initilization Done");
     Ok(())
 }

--- a/kernel/src/process_manager/mod.rs
+++ b/kernel/src/process_manager/mod.rs
@@ -1,7 +1,8 @@
 use memory_helper::set_ecryption_mask_address_size;
-use process::PROCESS_STORE;
 use process_memory::additional_monitor_memory_init;
+pub use process::PROCESS_STORE;
 
+use crate::attestation::monitor::measure;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
 pub mod call_handler;

--- a/kernel/src/process_manager/mod.rs
+++ b/kernel/src/process_manager/mod.rs
@@ -2,7 +2,6 @@ use memory_helper::set_ecryption_mask_address_size;
 use process_memory::additional_monitor_memory_init;
 pub use process::PROCESS_STORE;
 
-use crate::attestation::monitor::measure;
 use crate::utils::immut_after_init::ImmutAfterInitCell;
 
 pub mod call_handler;

--- a/kernel/src/process_manager/process.rs
+++ b/kernel/src/process_manager/process.rs
@@ -136,7 +136,7 @@ impl TrustedProcess {
         let libos_size= zygote_data_struct[5];
 
 
-        // The allocation is always starting at the same virtual address which is why only one allocaiton is valid
+        // The allocation (AllocationRange) is always starting at the same virtual address which is why only one allocaiton is valid
         // at the same time. TODO: Allow for different start addresses
         let (pal_data, pal_range) = ProcessPageTableRef::copy_data_from_guest(pal, pal_size, pgt);
         let mut base = ProcessBaseContext::default();

--- a/kernel/src/process_manager/process_memory.rs
+++ b/kernel/src/process_manager/process_memory.rs
@@ -40,7 +40,7 @@ pub struct ProcessMemConfig {
     free_page_list_table_entry: u64,
 }
 
-pub const ALLOCATION_RANGE_VIRT_START: u64 = 0x30000000000u64;
+pub const ALLOCATION_RANGE_VIRT_START: u64 = 0x300_0000_0000u64;
 
 static PROCESS_MEM_CONFIG: SpinLock<ProcessMemConfig> = SpinLock::new(ProcessMemConfig::new());
 pub static CPU_COUNT: ImmutAfterInitCell<u64> = ImmutAfterInitCell::new(0);
@@ -52,7 +52,7 @@ const MiB: usize = KiB * 1024;
 #[allow(non_upper_case_globals)]
 const GiB: usize = MiB * 1024;
 
-const ADDRESS_START_FREE_PAGE_LIST: usize = 0x8000000000;
+const ADDRESS_START_FREE_PAGE_LIST: usize = 0x80_0000_0000;
 
 const CONDITION_MIN_MEM_SIZE: usize = 1 * GiB;
 
@@ -74,7 +74,7 @@ impl ProcessMemConfig{
             initilized: false,
             total_size: 0,
             free: 0,
-            free_page_list: 0x8000000000u64,
+            free_page_list: ADDRESS_START_FREE_PAGE_LIST as u64,
             free_page_list_used_len: 0,
             page_top: PhysAddr::null(),
             page_base: PhysAddr::null(),

--- a/kernel/src/process_manager/process_paging.rs
+++ b/kernel/src/process_manager/process_paging.rs
@@ -15,6 +15,11 @@ use crate::process_manager::allocation::AllocationRange;
 
 use super::memory_helper::{ZERO_PAGE};
 
+// TP: Trusted Process
+const TP_STACK_START_VADDR: u64 = 0x80_0000_0000;
+const TP_MANIFEST_START_VADDR: u64 = 0x100_0000_0000;
+const TP_LIBOS_START_VADDR: u64 = 0x180_0000_0000;
+
 // Flags for the Page Table
 // In general all Trusted Processes need to
 // have user accessable set
@@ -269,7 +274,7 @@ impl ProcessPageTableRef {
             self.add_region(program_header, elf_file );
         }
         //Add stack
-        self.add_stack(VirtAddr::from(0x8000000000usize), 8);
+        self.add_stack(VirtAddr::from(TP_STACK_START_VADDR), 8);
         self.print_table();
         VirtAddr::from(elf.elf_hdr.e_entry)
     }
@@ -277,13 +282,13 @@ impl ProcessPageTableRef {
     pub fn add_manifest(&self, data: VirtAddr, size: u64) {
         let data: *mut u8 = data.as_mut_ptr::<u8>();
         let data = unsafe { slice::from_raw_parts(data, size as usize) };
-        self.add_region_vaddr(VirtAddr::from(0x10000000000u64), data);
+        self.add_region_vaddr(VirtAddr::from(TP_MANIFEST_START_VADDR), data);
     }
 
     pub fn add_libos(&self, data: VirtAddr, size: u64) {
         let data: *mut u8 = data.as_mut_ptr::<u8>();
         let data = unsafe { slice::from_raw_parts(data, size as usize) };
-        self.add_region_vaddr(VirtAddr::from(0x18000000000u64), data);
+        self.add_region_vaddr(VirtAddr::from(TP_LIBOS_START_VADDR), data);
     }
 
     pub fn add_pages(&self, start: VirtAddr, size: u64, flags: ProcessPageFlags) {


### PR DESCRIPTION
## This PR performs the following:
- Introduce `ProcessMasurements` structure in the `ProcessContext`. It currently includes the init (pal) measurement, the manifest measurement and the libos measurement that are calculated when a `Zygote` is loaded and inherited by the derived `Trustlets`.
- Add and set the `parent_id` field in the Trusted Process so that we know from which `Zygote` each `Trustlet` is derived.
- Enhance the call_handler of the monitor with the DIFF_ATTEST operation
- Implement the functions for getting the measurements.
	- The `measure` function takes a starting address and a size and returns the digest of this memory region
	- The `monitor_report` generates, stores and returns the SNP report
	- The `zygote_report` retrieves the `Zygote` measurements based on the `zygote_id` and returns the SNP report and the zygote measurement fields in a guest provided buffer
	- The `trustlet_report` retrieves the `Trustlet` measurements based on the `trustlet_id` and returns the SNP report and the trustlet measurement fields in a guest provided buffer
	- The `function_report` deserializes the struct with the `trustlet id`, function `input` and `output` provided from the guest, retrieves the `Trustlet` measurements and measures the `input` and `output`. Then, it returns the SNP report and the trustlet measurement fields as well as the function data measurements in a guest provided buffer
	- The `diff_attestation` determines which function to be called for each attestation type. It is mostly there for convenience as the user should call only the function attestation eventually.
- Add two getters for the report address and size in the `SnpReportResponse` struct
- Minor changes to satisfy the compiler checker
- Add monitor report generation in the `monitor_init()` step

## Test
To test it, you need to use the update `t.c` test provided in the `Wallet-VMPL` repo.
Versions:
- `Wallet-VMPL`: Branch: `dimstav23/update_test_with_attestation`, commit: `78f073bf832eea9939362e7595da9665fbcb156d`
- `gramine-svsm`: Branch: `dev` commit: `66b537682590c96d1e0f923e6dfadadd6197ac2d`

Steps:
1. Boot a VM
2. Log in via SSH
3. `cd module && make vmpl.ko && make reload && make t`
4. `./test 10`

This will do the following:
- `init` the monitor and retrieve its report
- create one `Zygote` and get its report
- create one `Trustlet` and get its report
- create one `function` with `input` and `output` data and get its report
- the reports are parsed and stored in the `module` directory with descriptive names and structure for better readability 
**Note**: 