### PR TITLE
Trustlet: Install exception handler

### DIFF
--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -35,11 +35,11 @@ impl GDTEntry {
     }
 
     pub const fn code_64_kernel() -> Self {
-        Self(0x00af9a000000ffffu64)
+        Self(0x00af9b000000ffffu64)
     }
 
     pub const fn data_64_kernel() -> Self {
-        Self(0x00cf92000000ffffu64)
+        Self(0x00cf93000000ffffu64)
     }
 
     pub const fn code_64_user() -> Self {
@@ -47,7 +47,7 @@ impl GDTEntry {
     }
 
     pub const fn data_64_user() -> Self {
-        Self(0x00cff2000000ffffu64)
+        Self(0x00cff3000000ffffu64)
     }
 }
 
@@ -116,7 +116,7 @@ impl GDT {
         }
     }
 
-    unsafe fn set_tss_entry(&mut self, desc0: GDTEntry, desc1: GDTEntry) {
+    pub unsafe fn set_tss_entry(&mut self, desc0: GDTEntry, desc1: GDTEntry) {
         let idx = (SVSM_TSS / 8) as usize;
 
         let tss_entries = &self.entries[idx..idx + 1].as_mut_ptr();

--- a/kernel/src/cpu/gdt.rs
+++ b/kernel/src/cpu/gdt.rs
@@ -54,6 +54,7 @@ impl GDTEntry {
 const GDT_SIZE: u16 = 8;
 
 #[derive(Copy, Clone, Debug)]
+#[repr(align(4096))]
 pub struct GDT {
     entries: [GDTEntry; GDT_SIZE as usize],
 }

--- a/kernel/src/cpu/idt/common.rs
+++ b/kernel/src/cpu/idt/common.rs
@@ -149,6 +149,7 @@ struct IdtDesc {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[repr(align(4096))]
 pub struct IDT {
     entries: [IdtEntry; IDT_ENTRIES],
 }

--- a/kernel/src/cpu/tss.rs
+++ b/kernel/src/cpu/tss.rs
@@ -12,7 +12,7 @@ pub const _IST_INVALID: usize = 0;
 pub const IST_DF: usize = 1;
 
 #[derive(Debug, Default, Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C, packed(4))]
 pub struct X86Tss {
     reserved1: u32,
     pub stacks: [VirtAddr; 3],

--- a/kernel/src/cpu/tss.rs
+++ b/kernel/src/cpu/tss.rs
@@ -59,4 +59,8 @@ impl X86Tss {
 
         (GDTEntry::from_raw(desc0), GDTEntry::from_raw(desc1))
     }
+
+    pub fn base(&self) -> u64 {
+        self as *const X86Tss as u64
+    }
 }

--- a/kernel/src/process_manager/mod.rs
+++ b/kernel/src/process_manager/mod.rs
@@ -22,6 +22,6 @@ pub fn monitor_init(){
     }
     set_ecryption_mask_address_size();
     let _ = additional_monitor_memory_init();
-    PROCESS_STORE.init(10);
+    PROCESS_STORE.init(128);
     let _ = MONITOR_INIT_STATE.reinit(&MONITOR_INIT_STATE_TRUE);
 }

--- a/kernel/src/process_manager/process.rs
+++ b/kernel/src/process_manager/process.rs
@@ -11,7 +11,7 @@ use crate::cpu::percpu::this_cpu_shared;
 use crate::cpu::percpu::this_cpu_unsafe;
 use crate::cpu::tss::{X86Tss,TSS_LIMIT};
 use crate::cpu::gdt::GDT;
-use crate::cpu::idt::common::{IDT, IdtEntry, PF_VECTOR};
+use crate::cpu::idt::common::{IdtEntry, DF_VECTOR, IDT, PF_VECTOR, GP_VECTOR};
 use crate::cpu::control_regs::read_cr3;
 use crate::mm::PAGE_SIZE;
 use crate::mm::pagetable::PageTableRef;
@@ -446,17 +446,55 @@ global_asm!(
        pushq %rbx
        movq 16(%rsp), %rbx      # load error code
        movq $0x4EFFFFFF, %rax   # monitor call number
-       cpuid
+       cpuid                    # call the monitor
+
+       movq %cr2, %rax          # load faulting address
+       invlpg (%rax)            # invalidate the page
+
        popq %rbx
        popq %rax
        addq $8, %rsp            # remove error code
+
        iretq
+
+    .global asm_entry_trustlet_df
+    asm_entry_trustlet_df:
+       # #DF pushes the error code on the stack
+       pushq %rax
+       pushq %rbx
+       pushq %rcx
+       movq 24(%rsp), %rbx      # load error code
+       movq $0x4EFFFFFE, %rax   # monitor call number
+       sgdt gdt_desc(%rip)      # store current GDT
+       lea gdt_desc(%rip), %rcx
+       cpuid
+       /* no return */
+
+    # debug
+    .section .data
+    .global gdt_desc
+    gdt_desc:
+    .word gdt_entry_end - gdt_entry - 1 # 2 bytes for the GDT limit
+    .quad gdt_entry                     # 8 bytes for the GDT base address
+    .align 256
+    gdt_entry:
+    .quad 0x0000000000000000  # null
+    .quad 0x00af9b000000ffff  # code_64_kernel
+    .quad 0x00cf93000000ffff  # data_64_kernel
+    .quad 0x00affb000000ffff  # code_64_user
+    .quad 0x00cff3000000ffff  # data_64_user
+    .quad 0x0000000000000000  # null
+    .quad 0x0000000000000000  # tss
+    .quad 0xAAAAAAAAAAAAAAAA  # tss
+    gdt_entry_end:
     "#,
     options(att_syntax)
 );
 
 extern "C" {
     fn asm_entry_trustlet_pf();
+    fn asm_entry_trustlet_df();
+    static gdt_desc: u8;
 }
 
 impl ProcessContext {
@@ -497,6 +535,7 @@ impl ProcessContext {
         vmsa.efer = vmsa.efer | 1u64 << 12;
         vmsa.rip = base.entry_point.into();
         vmsa.sev_features = old_vmsa_ptr.sev_features | 4; // 4 is for #VC Reflect
+        vmsa.rflags &= !(1u64 << 9); // Clear IF;
         // New Stack
         vmsa.rbp = u64::from(TP_STACK_START_VADDR)+8*4096-1;
         vmsa.rsp = u64::from(TP_STACK_START_VADDR)+8*4096-1;
@@ -511,8 +550,85 @@ impl ProcessContext {
         // FIXME: propery setup the page flags for the handler
         vmsa.cr4 = vmsa.cr4 & !(1u64 << 20 | 1u64 << 21);
 
+        log::info!("asm_entry_trustlet_pf: {:x}", asm_entry_trustlet_pf as u64);
+        log::info!("asm_entry_trustlet_df: {:x}", asm_entry_trustlet_df as u64);
+        log::info!("gdt_desc: {:x}", unsafe { &gdt_desc as *const u8 as u64 });
+
+        // setup IDT
+        // 1. setup IDT entry for #PF, #DF
+        idt_trustlet_mut().set_entry(PF_VECTOR, IdtEntry::trap_entry(asm_entry_trustlet_pf));
+        idt_trustlet_mut().set_entry(DF_VECTOR, IdtEntry::entry(asm_entry_trustlet_df));
+        //idt_trustlet_mut().set_entry(GP_VECTOR, IdtEntry::trap_entry(asm_entry_trustlet_df));
+        // 2. rmpadjust for IDT and handlers
+        let (idt_base, limit) = idt_trustlet().base_limit();
+        rmp_adjust(idt_base.into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
+        rmp_adjust((asm_entry_trustlet_pf as u64).into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
+        rmp_adjust((unsafe { &gdt_desc as *const u8 as u64 }).into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
+        // 3. map IDT and handlers to trustlet's page table
+        let idt_phys = svsm_page_table_ref.virt_to_phys(idt_base.into());
+        let handler_phys = svsm_page_table_ref.virt_to_phys((asm_entry_trustlet_pf as u64).into());
+        let gdt_desc_phys = svsm_page_table_ref.virt_to_phys((unsafe { &gdt_desc as *const u8 as u64 }).into());
+        assert!(idt_phys != PhysAddr::null());
+        assert!(handler_phys != PhysAddr::null());
+        assert!(gdt_desc_phys != PhysAddr::null());
+        // FIXME: this assertion is to check the virtual address is available, but this page could
+        // be also used by GDT/TSS and in that case the assertion will fail. Currently IDT and TSS
+        // is aligend to 4KB boundary to about this issue. Fix this by properly allocating and
+        // managing the page for IDT, TSS and GDT.
+        assert!(page_table_ref.virt_to_phys(idt_base.into()) == PhysAddr::null());
+        assert!(page_table_ref.virt_to_phys((asm_entry_trustlet_pf as u64).into()) == PhysAddr::null());
+        assert!(page_table_ref.virt_to_phys((unsafe { &gdt_desc as *const u8 as u64 }).into()) == PhysAddr::null());
+        page_table_ref.map_4k_page(idt_base.into(), idt_phys, ProcessPageFlags::exec());
+        page_table_ref.map_4k_page((asm_entry_trustlet_pf as u64).into(), handler_phys, ProcessPageFlags::exec());
+        page_table_ref.map_4k_page((unsafe { &gdt_desc as *const u8 as u64 }).into(), gdt_desc_phys, ProcessPageFlags::data());
+        // 4. setup IDT segment in VMSA
+        let vmsa_idt = VMSASegment {
+            selector: 0,
+            flags: 0x0,
+            base: idt_base,
+            limit: limit-1,
+        };
+        vmsa.idt = vmsa_idt;
+
+        // setup TSS
+        let mut tss = tss_trustlet_mut();
+        let tss_base = tss.base();
+        let num_page = 1;
+        // 1. setup kernel stack address
+        tss.stacks[0] = (TP_KERN_STACK_START_VADDR + 4096*num_page-16).into();
+        // 2. map the stack address to trustlet's page table
+        page_table_ref.add_stack(TP_KERN_STACK_START_VADDR.into(), num_page);
+        // 3. map the TSS to trustlet's page table
+        let tss_phys = svsm_page_table_ref.virt_to_phys(tss_base.into());
+        assert!(tss_phys != PhysAddr::null());
+        assert!(page_table_ref.virt_to_phys(tss_base.into()) == PhysAddr::null());
+        page_table_ref.map_4k_page(tss_base.into(), tss_phys, ProcessPageFlags::data());
+        // 4. rmpadjust for TSS
+        rmp_adjust(tss_base.into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
+        let vmsa_tss = VMSASegment {
+            selector: 6*8,
+            flags: 0x89, // TSS
+            base: tss_base,
+            limit: TSS_LIMIT as u32-1,
+        };
+        vmsa.tr = vmsa_tss;
+
         // setup GDT
+        // GDT entreies:
+        // 0. null
+        // 1. code_64_kernel
+        // 2. data_64_kernel
+        // 3. code_64_user
+        // 4. data_64_user
+        // 5. null
+        // 6-7. TSS
+        let (desc0, desc1) = tss.to_gdt_entry();
+        unsafe{
+            // this sets the entry 6 for TSS
+            gdt_trustlet_mut().set_tss_entry(desc0, desc1);
+        }
         let (base_gdt, limit) = gdt_trustlet().base_limit();
+        log::info!("GDT base: {:x}, limit: {:x}", base_gdt, limit);
         // 1. rmpadjust for GDT
         rmp_adjust(base_gdt.into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
         // 2. map GDT to trustlet's page table
@@ -530,58 +646,34 @@ impl ProcessContext {
         };
         vmsa.gdt = vmsa_gdt;
 
-        // setup IDT
-        // 1. setup IDT entry for #PF
-        idt_trustlet_mut().set_entry(PF_VECTOR, IdtEntry::entry(asm_entry_trustlet_pf));
-        // 2. rmpadjust for IDT and handlers
-        let (idt_base, limit) = idt_trustlet().base_limit();
-        rmp_adjust(idt_base.into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
-        rmp_adjust((asm_entry_trustlet_pf as u64).into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
-        // 3. map IDT and handlers to trustlet's page table
-        let idt_phys = svsm_page_table_ref.virt_to_phys(idt_base.into());
-        let handler_phys = svsm_page_table_ref.virt_to_phys((asm_entry_trustlet_pf as u64).into());
-        assert!(idt_phys != PhysAddr::null());
-        assert!(handler_phys != PhysAddr::null());
-        // FIXME: this assertion is to check the virtual address is available, but this page could
-        // be also used by GDT/TSS and in that case the assertion will fail. Currently IDT and TSS
-        // is aligend to 4KB boundary to about this issue. Fix this by properly allocating and
-        // managing the page for IDT, TSS and GDT.
-        assert!(page_table_ref.virt_to_phys(idt_base.into()) == PhysAddr::null());
-        assert!(page_table_ref.virt_to_phys((asm_entry_trustlet_pf as u64).into()) == PhysAddr::null());
-        page_table_ref.map_4k_page(idt_base.into(), idt_phys, ProcessPageFlags::exec());
-        page_table_ref.map_4k_page((asm_entry_trustlet_pf as u64).into(), handler_phys, ProcessPageFlags::exec());
-        // 4. setup IDT segment in VMSA
-        let vmsa_idt = VMSASegment {
-            selector: 0,
-            flags: 0,
-            base: idt_base,
-            limit: limit,
+        let cs = VMSASegment {
+            selector: 3*8 | 0x3,
+            flags: 0xAFB, // user, code, 4KB granularity, 64-bit
+            base: 0,
+            limit: 0xFFFF_FFFF,
         };
-        vmsa.idt = vmsa_idt;
+        let ds = VMSASegment {
+            selector: 4*8 | 0x3,
+            flags: 0xCF3, // user, data, 4KB granularity, 64-bit
+            base: 0,
+            limit: 0xFFFF_FFFF,
+        };
 
-        // setup TSS
-        let mut tss = tss_trustlet_mut();
-        let tss_base = tss.base();
-        let num_page = 1;
-        // 1. setup kernel stack address
-        tss.stacks[0] = (TP_KERN_STACK_START_VADDR + 4096*num_page-1).into();
-        // 2. map the stack address to trustlet's page table
-        page_table_ref.add_stack(TP_KERN_STACK_START_VADDR.into(), num_page);
-        // 3. map the TSS to trustlet's page table
-        let tss_phys = svsm_page_table_ref.virt_to_phys(tss_base.into());
-        assert!(tss_phys != PhysAddr::null());
-        assert!(page_table_ref.virt_to_phys(tss_base.into()) == PhysAddr::null());
-        page_table_ref.map_4k_page(tss_base.into(), tss_phys, ProcessPageFlags::data());
-        // 4. rmpadjust for TSS
-        rmp_adjust(tss_base.into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
-        let vmsa_tss = VMSASegment {
-            selector: 6*8, // use the same selector as the svsm -- but maybe this value does not
-                           // matter?
-            flags: 0x89,
-            base: tss_base,
-            limit: TSS_LIMIT as u32,
-        };
-        vmsa.tr = vmsa_tss;
+        vmsa.cs = cs;
+        vmsa.ds = ds;
+        vmsa.es = ds;
+        vmsa.fs = ds;
+        vmsa.ss = ds;
+
+        let efer = vmsa.efer;
+        let cr4 = vmsa.cr4;
+        let rflags = vmsa.rflags;
+        log::info!("vmsa EFER: {:?}", efer);
+        log::info!("vmsa cr4: {:?}", cr4);
+        log::info!("vmsa CS: {:?}", vmsa.cs);
+        log::info!("vmsa SS: {:?}", vmsa.ss);
+        log::info!("vmsa DS: {:?}", vmsa.ds);
+        log::info!("vmsa rflags: {:?}", rflags);
 
         // ------ end of exception handlers setup
 

--- a/kernel/src/process_manager/process.rs
+++ b/kernel/src/process_manager/process.rs
@@ -1,17 +1,25 @@
 extern crate alloc;
 
+use core::arch::global_asm;
 use core::cell::UnsafeCell;
 use alloc::vec::Vec;
+use cpuarch::vmsa::VMSASegment;
 use igvm_defs::PAGE_SIZE_4K;
+use crate::locking::{RWLock, ReadLockGuard, WriteLockGuard};
 use crate::address::PhysAddr;
 use crate::cpu::percpu::this_cpu_shared;
 use crate::cpu::percpu::this_cpu_unsafe;
+use crate::cpu::tss::{X86Tss,TSS_LIMIT};
+use crate::cpu::gdt::GDT;
+use crate::cpu::idt::common::{IDT, IdtEntry, PF_VECTOR};
+use crate::cpu::control_regs::read_cr3;
 use crate::mm::PAGE_SIZE;
 use crate::mm::pagetable::PageTableRef;
 use crate::mm::SVSM_PERCPU_VMSA_BASE;
 use crate::process_manager::process_memory::allocate_page;
 use crate::process_manager::allocation::AllocationRange;
 use crate::process_manager::process_paging::ProcessPageTableRef;
+use crate::process_manager::process_paging::ProcessPageFlags;
 use crate::protocols::errors::SvsmReqError;
 use crate::protocols::RequestParams;
 use crate::sev::RMPFlags;
@@ -28,6 +36,7 @@ use crate::vaddr_as_u64_slice;
 use cpuarch::vmsa::VMSA;
 use core::mem::replace;
 
+use super::process_paging::{TP_STACK_START_VADDR,TP_KERN_STACK_START_VADDR};
 use super::memory_channels::MemoryChannel;
 use crate::attestation::monitor::{ProcessMeasurements, measure};
 
@@ -389,6 +398,58 @@ impl Default for ProcessContext {
     }
 }
 
+// FIXME: Allocarte the GDT, IDT, and TSS in a dedicated page
+/// GDT for Trustlets (shared between all Trustlets)
+static GDT_TRUSTLET: RWLock<GDT> = RWLock::new(GDT::new());
+
+fn gdt_trustlet() -> ReadLockGuard<'static, GDT> {
+    GDT_TRUSTLET.lock_read()
+}
+
+fn gdt_trustlet_mut() -> WriteLockGuard<'static, GDT> {
+    GDT_TRUSTLET.lock_write()
+}
+
+/// IDT for Trustlets (shared between all Trustlets)
+static IDT_TRUSTLET: RWLock<IDT> = RWLock::new(IDT::new());
+
+fn idt_trustlet() -> ReadLockGuard<'static, IDT> {
+    IDT_TRUSTLET.lock_read()
+}
+
+fn idt_trustlet_mut() -> WriteLockGuard<'static, IDT> {
+    IDT_TRUSTLET.lock_write()
+}
+
+/// TSS for Trustlets
+// FIXME: the current implementation use the same TSS for all Trustlets. This works because
+// the only one Trustlet runs at a time.
+static TSS_TRUSTLET: RWLock<X86Tss> = RWLock::new(X86Tss::new());
+
+fn tss_trustlet() -> ReadLockGuard<'static, X86Tss> {
+    TSS_TRUSTLET.lock_read()
+}
+
+fn tss_trustlet_mut() -> WriteLockGuard<'static, X86Tss> {
+    TSS_TRUSTLET.lock_write()
+}
+
+global_asm!(
+    r#"
+    .align 4096
+    .code64
+    .section .text
+    .global asm_entry_trustlet_pf
+    asm_entry_trustlet_pf:
+       movq $1234, %rax
+       cpuid
+    "#,
+    options(att_syntax)
+);
+
+extern "C" {
+    fn asm_entry_trustlet_pf();
+}
 
 impl ProcessContext {
 
@@ -429,8 +490,92 @@ impl ProcessContext {
         vmsa.rip = base.entry_point.into();
         vmsa.sev_features = old_vmsa_ptr.sev_features | 4; // 4 is for #VC Reflect
         // New Stack
-        vmsa.rbp = u64::from(0x8000000000u64)+8*4096-1;
-        vmsa.rsp = u64::from(0x8000000000u64)+8*4096-1;
+        vmsa.rbp = u64::from(TP_STACK_START_VADDR)+8*4096-1;
+        vmsa.rsp = u64::from(TP_STACK_START_VADDR)+8*4096-1;
+
+        // ---
+        // Setup exception handlers
+
+        let mut svsm_page_table_ref = ProcessPageTableRef::default();
+        svsm_page_table_ref.set_external_table(read_cr3().into());
+
+        // disable SMAP/SMEP to execute the handler in ring0
+        // FIXME: propery setup the page flags for the handler
+        vmsa.cr4 = vmsa.cr4 & !(1u64 << 20 | 1u64 << 21);
+
+        // setup GDT
+        let (base_gdt, limit) = gdt_trustlet().base_limit();
+        // 1. rmpadjust for GDT
+        rmp_adjust(base_gdt.into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
+        // 2. map GDT to trustlet's page table
+        let gdt_phys = svsm_page_table_ref.virt_to_phys(base_gdt.into());
+        assert!(gdt_phys != PhysAddr::null());
+        // FIXME: currently use the same virtual address as the SVSM for the trustlet
+        assert!(page_table_ref.virt_to_phys(base_gdt.into()) == PhysAddr::null());
+        page_table_ref.map_4k_page(base_gdt.into(), gdt_phys, ProcessPageFlags::data());
+        // 3. setup GDT segment in VMSA
+        let vmsa_gdt = VMSASegment {
+            selector: 0,
+            flags: 0,
+            base: base_gdt,
+            limit: limit,
+        };
+        vmsa.gdt = vmsa_gdt;
+
+        // setup IDT
+        // 1. setup IDT entry for #PF
+        idt_trustlet_mut().set_entry(PF_VECTOR, IdtEntry::entry(asm_entry_trustlet_pf));
+        // 2. rmpadjust for IDT and handlers
+        let (idt_base, limit) = idt_trustlet().base_limit();
+        rmp_adjust(idt_base.into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
+        rmp_adjust((asm_entry_trustlet_pf as u64).into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
+        // 3. map IDT and handlers to trustlet's page table
+        let idt_phys = svsm_page_table_ref.virt_to_phys(idt_base.into());
+        let handler_phys = svsm_page_table_ref.virt_to_phys((asm_entry_trustlet_pf as u64).into());
+        assert!(idt_phys != PhysAddr::null());
+        assert!(handler_phys != PhysAddr::null());
+        // FIXME: this assertion is to check the virtual address is available, but this page could
+        // be also used by GDT/TSS and in that case the assertion will fail. Currently IDT and TSS
+        // is aligend to 4KB boundary to about this issue. Fix this by properly allocating and
+        // managing the page for IDT, TSS and GDT.
+        assert!(page_table_ref.virt_to_phys(idt_base.into()) == PhysAddr::null());
+        assert!(page_table_ref.virt_to_phys((asm_entry_trustlet_pf as u64).into()) == PhysAddr::null());
+        page_table_ref.map_4k_page(idt_base.into(), idt_phys, ProcessPageFlags::exec());
+        page_table_ref.map_4k_page((asm_entry_trustlet_pf as u64).into(), handler_phys, ProcessPageFlags::exec());
+        // 4. setup IDT segment in VMSA
+        let vmsa_idt = VMSASegment {
+            selector: 0,
+            flags: 0,
+            base: idt_base,
+            limit: limit,
+        };
+        vmsa.idt = vmsa_idt;
+
+        // setup TSS
+        let mut tss = tss_trustlet_mut();
+        let tss_base = tss.base();
+        let num_page = 1;
+        // 1. setup kernel stack address
+        tss.stacks[0] = (TP_KERN_STACK_START_VADDR + 4096*num_page-1).into();
+        // 2. map the stack address to trustlet's page table
+        page_table_ref.add_stack(TP_KERN_STACK_START_VADDR.into(), num_page);
+        // 3. map the TSS to trustlet's page table
+        let tss_phys = svsm_page_table_ref.virt_to_phys(tss_base.into());
+        assert!(tss_phys != PhysAddr::null());
+        assert!(page_table_ref.virt_to_phys(tss_base.into()) == PhysAddr::null());
+        page_table_ref.map_4k_page(tss_base.into(), tss_phys, ProcessPageFlags::data());
+        // 4. rmpadjust for TSS
+        rmp_adjust(tss_base.into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
+        let vmsa_tss = VMSASegment {
+            selector: 6*8, // use the same selector as the svsm -- but maybe this value does not
+                           // matter?
+            flags: 0x89,
+            base: tss_base,
+            limit: TSS_LIMIT as u32,
+        };
+        vmsa.tr = vmsa_tss;
+
+        // ------ end of exception handlers setup
 
         //Check VMSA
         let svme_mask: u64 = 1u64 << 12;

--- a/kernel/src/process_manager/process.rs
+++ b/kernel/src/process_manager/process.rs
@@ -441,8 +441,16 @@ global_asm!(
     .section .text
     .global asm_entry_trustlet_pf
     asm_entry_trustlet_pf:
-       movq $1234, %rax
+       # #PF pushes the error code on the stack
+       pushq %rax
+       pushq %rbx
+       movq 16(%rsp), %rbx      # load error code
+       movq $0x4EFFFFFF, %rax   # monitor call number
        cpuid
+       popq %rbx
+       popq %rax
+       addq $8, %rsp            # remove error code
+       iretq
     "#,
     options(att_syntax)
 );

--- a/kernel/src/process_manager/process_paging.rs
+++ b/kernel/src/process_manager/process_paging.rs
@@ -17,6 +17,7 @@ use super::memory_helper::{ZERO_PAGE};
 
 // TP: Trusted Process
 pub const TP_STACK_START_VADDR: u64 = 0x80_0000_0000;
+pub const TP_KERN_STACK_START_VADDR: u64 = 0x90_0000_0000;
 pub const TP_MANIFEST_START_VADDR: u64 = 0x100_0000_0000;
 pub const TP_LIBOS_START_VADDR: u64 = 0x180_0000_0000;
 

--- a/kernel/src/process_manager/process_paging.rs
+++ b/kernel/src/process_manager/process_paging.rs
@@ -50,6 +50,7 @@ bitflags! {
         const DIRTY =           1 << 6;
         const HUGE_PAGE =       1 << 7;
         const GLOBAL =          1 << 8;
+        const COPY_ON_WRITE =   1 << 9; // Use this field to mark CoW pages
 
         const NO_EXECUTE =      1 << 63;
     }
@@ -627,5 +628,61 @@ impl ProcessPageTableRef {
         assert!(self.process_page_table != PhysAddr::null());
         assert!(other.process_page_table != PhysAddr::null());
         self._copy_page_table(other.process_page_table, self.process_page_table, 4);
+    }
+
+    pub fn handle_cow(&mut self, addr: VirtAddr, user_access: bool) -> bool {
+        // Handle CoW for the page at the given address
+        // log::info!("[handle_cow] addr: {:#x}, user_access: {}", addr, user_access);
+        let (_pgd_mapping, pgd_table) = paddr_as_table!(self.process_page_table);
+        let current_mapping = self.page_walk(&pgd_table, self.process_page_table, addr);
+
+        // log::info!("[handle_cow] current_mapping: {:?}", current_mapping);
+
+        match current_mapping {
+            ProcessTableLevelMapping::PTE(table_phys, index) => {
+                let (_mapping, table) = paddr_as_table!(table_phys);
+                let entry = table[index];
+                let entry_phys = PhysAddr::from(entry.0.bits() & 0xFFFF_FFFF_F000);
+                let entry_flags = entry.flags();
+
+                if entry_flags.contains(ProcessPageFlags::WRITABLE) {
+                    // the page is already writable, no need to handle CoW
+                    log::warn!("[handle_cow] the page already writable, skip");
+                    return false;
+                }
+                if user_access && !entry_flags.contains(ProcessPageFlags::USER_ACCESSIBLE) {
+                    // the page is not user-accessible, skip
+                    log::warn!("[handle_cow] the page not user-accessible, skip");
+                    return false;
+                }
+                if !entry_flags.contains(ProcessPageFlags::COPY_ON_WRITE) {
+                    // the page is not-marked as CoW, skip
+                    log::warn!("[handle_cow] the page not marked as CoW, skip");
+                    return false;
+                }
+
+                let new_page = allocate_page();
+                let (_new_mapping, new_data) = paddr_as_slice!(new_page, u64);
+                let (_old_mapping, old_data) = paddr_as_slice!(entry_phys, u64);
+                rmp_adjust(_new_mapping.virt_addr(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
+
+                for i in 0..512 {
+                    new_data[i] = old_data[i];
+                }
+
+                // Set writable flag and clear CoW flag
+                let flag = entry_flags.bits() | ProcessPageFlags::WRITABLE.bits() & !ProcessPageFlags::COPY_ON_WRITE.bits();
+                table[index].set(new_page, ProcessPageFlags::from_bits_truncate(flag));
+
+                // log::info!("[handle_cow] CoW done, new_page: {:#x}", new_page);
+
+                return true;
+            },
+            _ => {
+                // page non-present, skip
+                log::warn!("[handle_cow] page non-present, skip");
+                return false;
+            }
+        }
     }
 }

--- a/kernel/src/process_runtime/runtime.rs
+++ b/kernel/src/process_runtime/runtime.rs
@@ -24,6 +24,7 @@ pub trait ProcessRuntime {
     fn pal_svsm_print_info(&mut self) -> bool;
     fn pal_svsm_set_tcb(&mut self) -> bool;
     fn pal_svsm_cpuid(&mut self) -> bool;
+    fn handle_exception(&mut self) -> bool;
 }
 
 #[derive(Debug)]
@@ -102,9 +103,11 @@ impl ProcessRuntime for PALContext  {
         vmsa.rip += 2;
 
         match rax {
+            // normal cpuid
             0..=23 | 0x80000000..=0x80000021 => {
                 return self.pal_svsm_cpuid();
             }
+            // monitor calls from the Gramine PAL
             0x4FFFFFFF => {
                 return self.pal_svsm_fail();
             }
@@ -126,6 +129,11 @@ impl ProcessRuntime for PALContext  {
             0x4FFFFFF9 => {
                 return self.pal_svsm_mprotect();
             }
+            // monitor calls (other)
+            0x4EFFFFFF => {
+                return self.handle_exception();
+            }
+            // debug
             99 => {
                 let c = vmsa.rbx;
                 log::info!("{}", c);
@@ -500,5 +508,33 @@ impl ProcessRuntime for PALContext  {
         log::info!("RDX: {:#x}", rdx);
 
         return true;
+    }
+
+    /// Handle an exception occured in the trustlet
+    fn handle_exception(&mut self) -> bool {
+        let cr2 = self.vmsa.cr2;
+        let error_code = self.vmsa.rbx;
+        const PF_PRESENT: u64 = 1 << 0;
+        const PF_WRITE: u64 = 1 << 1;
+        const PF_USER: u64 = 1 << 2;
+        const PF_RESERVED: u64 = 1 << 3;
+        const PF_INSTRUCTION: u64 = 1 << 4;
+        log::info!(" [Trustlet] Exception: CR2={:#x}, Error code={:?}", cr2, error_code);
+        if error_code & PF_PRESENT == 0 {
+            log::info!(" [Trustlet] Page fault: not present");
+        }
+        if error_code & PF_WRITE != 0 {
+            log::info!(" [Trustlet] Page fault: write");
+        }
+        if error_code & PF_USER != 0 {
+            log::info!(" [Trustlet] Page fault: user");
+        }
+        if error_code & PF_RESERVED != 0 {
+            log::info!(" [Trustlet] Page fault: reserved");
+        }
+        if error_code & PF_INSTRUCTION != 0 {
+            log::info!(" [Trustlet] Page fault: instruction fetch");
+        }
+        false
     }
 }

--- a/kernel/src/process_runtime/runtime.rs
+++ b/kernel/src/process_runtime/runtime.rs
@@ -226,7 +226,7 @@ impl ProcessRuntime for PALContext  {
         page_table_ref.set_external_table(page_table);
 
         let addr = self.vmsa.rbx;
-        let mut size = self.vmsa.rcx;
+        let size = self.vmsa.rcx;
         let flags = self.vmsa.rdx;
 
         // Check if size is a multiple of pages
@@ -241,8 +241,18 @@ impl ProcessRuntime for PALContext  {
             return true;
         }
         let mut page_flags = ProcessPageFlags::data();
-        if flags & 0x2 == 0x2 {
+        if flags & GraminePalProtFlags::WRITE.bits() != 0{
             page_flags = page_flags | ProcessPageFlags::WRITABLE;
+        }
+        /*
+        // XXX: we can omit this for now as currently we support only one thread
+        if flags & GraminePalProtFlags::WRITECOPY.bits() != 0 {
+            page_flags = page_flags | ProcessPageFlags::COPY_ON_WRITE;
+            page_flags = page_flags & !ProcessPageFlags::WRITABLE;
+        }
+        */
+        if flags & GraminePalProtFlags::EXEC.bits() != 0{
+            page_flags = page_flags & !ProcessPageFlags::NO_EXECUTE;
         }
         //log::info!("Trying to allocate: {:#?}, {} {:?}", addr, size,page_flags);
         page_table_ref.add_pages(VirtAddr::from(addr), size / 4096, page_flags);
@@ -356,6 +366,10 @@ impl ProcessRuntime for PALContext  {
         let mut page_table_ref = ProcessPageTableRef::default();
         page_table_ref.set_external_table(page_table);
 
+        assert!(addr % 4096 == 0, "Address is not page aligned");
+        assert!(size % 4096 == 0, "Size is not multiple of page size");
+        assert!(offset % 4096 == 0, "Offset is not page aligned");
+
         if size % 4096 != 0 {
             self.vmsa.rcx = u64::from_ne_bytes((-1i64).to_ne_bytes());
             return false;
@@ -374,18 +388,30 @@ impl ProcessRuntime for PALContext  {
         }
         if writecopy {
             flags |= ProcessPageFlags::COPY_ON_WRITE;
+            flags &= !ProcessPageFlags::WRITABLE;
         }
         if !executable {
             flags |= ProcessPageFlags::NO_EXECUTE;
         }
 
         for i in 0..num_pages {
-            let t = page_table_ref.virt_to_phys(s_vaddr + ((i * PAGE_SIZE_4K) as usize) + (offset as usize));
+            let src = s_vaddr + ((i * PAGE_SIZE_4K) as usize) + (offset as usize);
+            let dst = vaddr + (i * PAGE_SIZE_4K).try_into().unwrap(); 
+            let t = page_table_ref.virt_to_phys(src);
 
             /*
-            page_table_ref.map_4k_page(vaddr + (i * PAGE_SIZE_4K).try_into().unwrap(), t, flags);
-            let t2 = page_table_ref.virt_to_phys(vaddr + ((i * PAGE_SIZE_4K) as usize) );
+            // CoW version
+            // FIXME: this does not work (unknown #PF with non-present page occurs)
+            page_table_ref.map_4k_page(dst, t, flags);
+
+            if writecopy {
+                page_table_ref.change_attr(src, true, false, true, true);
+                // TODO: flush trustleet's TLB
+            }
+            // check
+            let t2 = page_table_ref.virt_to_phys(dst);
             assert!(t == t2, "Address mapping failed");
+            continue;
             */
 
             // Non-CoW version (copy page content at this point for writecopy)
@@ -398,14 +424,12 @@ impl ProcessRuntime for PALContext  {
                    new_page_mapped[i] = old_page_mapped[i];
                 }
                 let flags = flags | ProcessPageFlags::WRITABLE;
-                page_table_ref.map_4k_page(vaddr + (i* PAGE_SIZE_4K).try_into().unwrap(), new_page, flags);
+                page_table_ref.map_4k_page(dst, new_page, flags);
             } else {
-                page_table_ref.map_4k_page(vaddr + (i * PAGE_SIZE_4K).try_into().unwrap(), t, flags);
+                page_table_ref.map_4k_page(dst, t, flags);
 
-                let t2 = page_table_ref.virt_to_phys(vaddr + ((i * PAGE_SIZE_4K) as usize) );
-                if t != t2 {
-                    panic!("Address mapping failed");
-                }
+                let t2 = page_table_ref.virt_to_phys(dst);
+                assert!(t == t2, "Address mapping failed");
             }
         }
 

--- a/kernel/src/process_runtime/runtime.rs
+++ b/kernel/src/process_runtime/runtime.rs
@@ -25,6 +25,7 @@ pub trait ProcessRuntime {
     fn pal_svsm_set_tcb(&mut self) -> bool;
     fn pal_svsm_cpuid(&mut self) -> bool;
     fn handle_exception(&mut self) -> bool;
+    fn handle_df(&mut self) -> bool;
 }
 
 #[derive(Debug)]
@@ -133,6 +134,9 @@ impl ProcessRuntime for PALContext  {
             0x4EFFFFFF => {
                 return self.handle_exception();
             }
+            0x4EFFFFFE => {
+                return self.handle_df();
+            }
             // debug
             99 => {
                 let c = vmsa.rbx;
@@ -147,6 +151,9 @@ impl ProcessRuntime for PALContext  {
             }
             _ => {
                 log::info!("Unknown request code: {} (rip={:x})", rax, rip);
+                let rbx = vmsa.rbx;
+                log::info!("rbx {:?}", rbx);
+                log::info!("vmsa CS: {:?}", self.vmsa.cs);
                 return false;
             }
 
@@ -343,7 +350,7 @@ impl ProcessRuntime for PALContext  {
         let fd = self.vmsa.r8;
         let offset = self.vmsa.r9;
 
-        log::info!("{:#}, {}", addr, size);
+        log::info!("[pal_svsm_map] addr={:#x}, size={}", addr, size);
 
         let page_table = self.vmsa.cr3;
         let mut page_table_ref = ProcessPageTableRef::default();
@@ -362,8 +369,11 @@ impl ProcessRuntime for PALContext  {
         let executable = (flags & GraminePalProtFlags::EXEC.bits()) != 0;
         let writecopy = (flags & GraminePalProtFlags::WRITECOPY.bits()) != 0;
         let mut flags = ProcessPageFlags::PRESENT | ProcessPageFlags::USER_ACCESSIBLE | ProcessPageFlags::ACCESSED;
-        if writable || writecopy {
+        if writable {
             flags |= ProcessPageFlags::WRITABLE;
+        }
+        if writecopy {
+            flags |= ProcessPageFlags::COPY_ON_WRITE;
         }
         if !executable {
             flags |= ProcessPageFlags::NO_EXECUTE;
@@ -371,9 +381,15 @@ impl ProcessRuntime for PALContext  {
 
         for i in 0..num_pages {
             let t = page_table_ref.virt_to_phys(s_vaddr + ((i * PAGE_SIZE_4K) as usize) + (offset as usize));
-            //log::info!("{:#x}, {:#x}, {:#} {:#?}",s_vaddr,offset, s_vaddr + ((i * PAGE_SIZE_4K) as usize) + (offset as usize), t);
+
+            /*
+            page_table_ref.map_4k_page(vaddr + (i * PAGE_SIZE_4K).try_into().unwrap(), t, flags);
+            let t2 = page_table_ref.virt_to_phys(vaddr + ((i * PAGE_SIZE_4K) as usize) );
+            assert!(t == t2, "Address mapping failed");
+            */
+
+            // Non-CoW version (copy page content at this point for writecopy)
             if writecopy {
-                // FIXME: for now we do not support CoW, so copy the page at this point
                 let (_old_mapping, old_page_mapped) = paddr_as_slice!(t);
                 let new_page = allocate_page();
                 let (mapping, new_page_mapped) = paddr_as_slice!(new_page);
@@ -381,31 +397,16 @@ impl ProcessRuntime for PALContext  {
                 for i in 0..512 {
                    new_page_mapped[i] = old_page_mapped[i];
                 }
+                let flags = flags | ProcessPageFlags::WRITABLE;
                 page_table_ref.map_4k_page(vaddr + (i* PAGE_SIZE_4K).try_into().unwrap(), new_page, flags);
-
-                //log::info!("Copy Mapping Virt:{:#x} Phys:{:#x} to Virt:{:#x} Phys:{:#x}",
-                //           s_vaddr + ((i * PAGE_SIZE_4K) as usize) + (offset as usize),
-                //           t,
-                //           vaddr + ((i*PAGE_SIZE_4K) as usize),
-                //           new_page,
-                //);
-
             } else {
                 page_table_ref.map_4k_page(vaddr + (i * PAGE_SIZE_4K).try_into().unwrap(), t, flags);
 
                 let t2 = page_table_ref.virt_to_phys(vaddr + ((i * PAGE_SIZE_4K) as usize) );
-
-                //log::info!("Mapping Virt:{:#x} Phys:{:#x} to Virt:{:#x} Phys:{:#x}",
-                //s_vaddr + ((i * PAGE_SIZE_4K) as usize) + (offset as usize),
-                //           t,
-                //           vaddr + ((i*PAGE_SIZE_4K) as usize),
-                //           t2
-                //);
                 if t != t2 {
                     panic!("Address mapping failed");
                 }
             }
-
         }
 
         self.vmsa.rcx = u64::from_ne_bytes((0i64).to_ne_bytes());
@@ -511,7 +512,36 @@ impl ProcessRuntime for PALContext  {
     }
 
     /// Handle an exception occured in the trustlet
+    // XXX: Currently this function assumes that the exception is a #PF
     fn handle_exception(&mut self) -> bool {
+        // debug
+        let efer = self.vmsa.efer;
+        let rip = self.vmsa.rip;
+        let cr2 = self.vmsa.cr2;
+        let cr4 = self.vmsa.cr4;
+        let rsp = self.vmsa.rsp;
+        let rflags = self.vmsa.rflags;
+        log::info!(" [Trustlet] Page Fault!");
+        log::info!("vmsa EFER: {:?}", efer);
+        log::info!("vmsa CR2: {:?}", cr2);
+        log::info!("vmsa cr4: {:?}", cr4);
+        log::info!("vmsa rip: {:?}", rip);
+        log::info!("vmsa CS: {:?}", self.vmsa.cs);
+        log::info!("vmsa SS: {:?}", self.vmsa.ss);
+        log::info!("vmsa DS: {:?}", self.vmsa.ds);
+        log::info!("vmsa RFLAGS: {:?}", rflags);
+        log::info!("vmsa rsp: {:?}", rsp);
+        let mut process_page_table_ref = ProcessPageTableRef::default();
+        process_page_table_ref.set_external_table(self.vmsa.cr3);
+        // dump stack
+        let stack_base_paddr = process_page_table_ref.get_page(VirtAddr::from(rsp));
+        let offset = (rsp & 0xFFF) / 8;
+        let (_mapping, stack_mapping) = map_paddr!(stack_base_paddr);
+        for i in 0..9 {
+            log::info!(" [Trustlet] Stack (rsp+{}): {:#x}", i*8, unsafe{stack_mapping.as_ptr::<u64>().offset((offset + i).try_into().unwrap()).read()});
+        }
+
+        let rip= self.vmsa.rip;
         let cr2 = self.vmsa.cr2;
         let error_code = self.vmsa.rbx;
         const PF_PRESENT: u64 = 1 << 0;
@@ -519,7 +549,29 @@ impl ProcessRuntime for PALContext  {
         const PF_USER: u64 = 1 << 2;
         const PF_RESERVED: u64 = 1 << 3;
         const PF_INSTRUCTION: u64 = 1 << 4;
-        log::info!(" [Trustlet] Exception: CR2={:#x}, Error code={:?}", cr2, error_code);
+        if (error_code & PF_PRESENT != 0) && (error_code & PF_WRITE != 0) {
+            let mut page_table_ref = ProcessPageTableRef::default();
+            page_table_ref.set_external_table(self.vmsa.cr3);
+            // Handle CoW
+            log::info!(" [Trustlet] CoW: RIP={:#x}, CR2={:#x}, Error code={:?}", rip, cr2, error_code);
+            let user_access = error_code & PF_USER != 0;
+            let handled = page_table_ref.handle_cow(VirtAddr::from(cr2), user_access);
+            if handled {
+                log::info!(" [Trustlet] CoW: handled");
+                return true;
+            }
+        }
+
+        /*
+        // debug: allocate a page for the faulting address
+        let mut page_table_ref = ProcessPageTableRef::default();
+        page_table_ref.set_external_table(self.vmsa.cr3);
+        page_table_ref.add_pages(VirtAddr::from(cr2), 1, ProcessPageFlags::data());
+        return true;
+        */
+
+        // #PF for other reasons
+        log::info!(" [Trustlet] Unhandled #PF: RIP={:#x}, CR2={:#x}, Error code={:?}", rip, cr2, error_code);
         if error_code & PF_PRESENT == 0 {
             log::info!(" [Trustlet] Page fault: not present");
         }
@@ -535,6 +587,115 @@ impl ProcessRuntime for PALContext  {
         if error_code & PF_INSTRUCTION != 0 {
             log::info!(" [Trustlet] Page fault: instruction fetch");
         }
+        false
+    }
+
+    // handle double fault
+    fn handle_df(&mut self) -> bool {
+        log::info!(" [Trustlet] ---------------------------------");
+        log::info!(" [Trustlet] Double Fault!");
+
+        let error_code = self.vmsa.rbx;
+        log::info!(" [Trustlet] Error Code: {:#x}", error_code);
+
+        // Dump stack
+        // Stak layout:
+        // rsp + 0: rcx  (pushed by the hanlder)
+        // rsp + 8: rbx  (pushed by the hanlder)
+        // rsp + 16: rax (pushed by the hanlder)
+        // rsp + 24: error_code
+        // rsp + 32: rip
+        // rsp + 40: cs
+        // rsp + 48: rflags
+        // rsp + 54: rsp
+        // rsp + 64: ss
+        let mut process_page_table_ref = ProcessPageTableRef::default();
+        process_page_table_ref.set_external_table(self.vmsa.cr3);
+        let rsp = self.vmsa.rsp;
+        let stack_base_paddr = process_page_table_ref.get_page(VirtAddr::from(rsp));
+        let offset = (rsp & 0xFFF) / 8;
+        let (_mapping, stack_mapping) = map_paddr!(stack_base_paddr);
+        for i in 0..9 {
+            log::info!(" [Trustlet] Stack (rsp+{}): {:#x}", i*8, unsafe{stack_mapping.as_ptr::<u64>().offset((offset + i).try_into().unwrap()).read()});
+        }
+
+        // Dump GDT
+        // RCX register points to the GDT (limit (2byte) + base (4byte))
+        let gdt_ptr = self.vmsa.rcx;
+        let page = process_page_table_ref.get_page(VirtAddr::from(gdt_ptr));
+        let gdt_offset = (gdt_ptr & 0xFFF) as usize;
+        let (_mapping, gdt_mapping) = map_paddr!(page);
+        let gdt_limit = unsafe{gdt_mapping.as_ptr::<u8>().add(gdt_offset).cast::<u16>().read()};
+        let gdt_base = unsafe{gdt_mapping.as_ptr::<u8>().add(gdt_offset+2).cast::<u64>().read()};
+        log::info!(" [Trustlet] gdt_ptr: {:#x}", gdt_ptr);
+        log::info!(" [Trustlet] GDT: limit={:#x}, base={:#x}", gdt_limit, gdt_base);
+        let gdt_page = process_page_table_ref.get_page(VirtAddr::from(gdt_base));
+        let (_mapping, gdt_mapping) = map_paddr!(gdt_page);
+        let gdt_entries = gdt_limit as usize / 8;
+        let gdt_entry_offset = (gdt_base & 0xFFF) as usize;
+        for i in 0..=gdt_entries {
+            let entry = unsafe{gdt_mapping.as_ptr::<u8>().add(gdt_entry_offset).cast::<u64>().add(i).read()};
+            log::info!(" [Trustlet] GDT[{}]: {:#x}", i, entry);
+        }
+        
+        // Dump CPU state
+        // rax, rbx are pushed to the stack
+        let rax = unsafe{stack_mapping.as_ptr::<u64>().offset((offset + 2).try_into().unwrap()).read()};
+        let rbx = unsafe{stack_mapping.as_ptr::<u64>().offset((offset + 1).try_into().unwrap()).read()};
+        let rcx = unsafe{stack_mapping.as_ptr::<u64>().offset((offset + 0).try_into().unwrap()).read()};
+        let rdx = self.vmsa.rdx;
+        let rsi = self.vmsa.rsi;
+        let rdi = self.vmsa.rdi;
+        let r8 = self.vmsa.r8;
+        let r9 = self.vmsa.r9;
+        let r10 = self.vmsa.r10;
+        let r11 = self.vmsa.r11;
+        let r12 = self.vmsa.r12;
+        let r13 = self.vmsa.r13;
+        let r14 = self.vmsa.r14;
+        let r15 = self.vmsa.r15;
+
+        log::info!(" [Trustlet] rax: {:#x}", rax);
+        log::info!(" [Trustlet] rbx: {:#x}", rbx);
+        log::info!(" [Trustlet] rcx: {:#x}", rcx);
+        log::info!(" [Trustlet] rdx: {:#x}", rdx);
+        log::info!(" [Trustlet] rsi: {:#x}", rsi);
+        log::info!(" [Trustlet] rdi: {:#x}", rdi);
+        log::info!(" [Trustlet] r8: {:#x}", r8);
+        log::info!(" [Trustlet] r9: {:#x}", r9);
+        log::info!(" [Trustlet] r10: {:#x}", r10);
+        log::info!(" [Trustlet] r11: {:#x}", r11);
+        log::info!(" [Trustlet] r12: {:#x}", r12);
+        log::info!(" [Trustlet] r13: {:#x}", r13);
+        log::info!(" [Trustlet] r14: {:#x}", r14);
+        log::info!(" [Trustlet] r15: {:#x}", r15);
+
+        let rip = self.vmsa.rip;
+        let rsp = self.vmsa.rsp;
+
+        log::info!(" [Trustlet] rip: {:#x}", rip);
+        log::info!(" [Trustlet] rsp: {:#x}", rsp);
+
+        let cr2 = self.vmsa.cr2;
+        let cr3 = self.vmsa.cr3;
+        let cr4 = self.vmsa.cr4;
+        let rflags = self.vmsa.rflags;
+        let efer = self.vmsa.efer;
+
+        log::info!(" [Trustlet] cr2: {:#x}", cr2);
+        log::info!(" [Trustlet] cr3: {:#x}", cr3);
+        log::info!(" [Trustlet] cr4: {:#x}", cr4);
+        log::info!(" [Trustlet] efer: {:#x}", efer);
+        log::info!(" [Trustlet] rflags: {:#x}", rflags);
+
+        let cs = self.vmsa.cs;
+        let ss = self.vmsa.ss;
+        let ds = self.vmsa.ds;
+        log::info!(" [Trustlet] cs: {:?}", cs);
+        log::info!(" [Trustlet] ss: {:?}", ss);
+        log::info!(" [Trustlet] ds: {:?}", ds);
+
+        log::info!(" [Trustlet] ---------------------------------");
         false
     }
 }

--- a/kernel/src/types.rs
+++ b/kernel/src/types.rs
@@ -33,7 +33,7 @@ pub const SVSM_USER_CS: u16 = 3 * 8;
 pub const SVSM_USER_DS: u16 = 4 * 8;
 pub const SVSM_TSS: u16 = 6 * 8;
 
-pub const SVSM_CS_FLAGS: u16 = 0x29b;
+pub const SVSM_CS_FLAGS: u16 = 0xa9b;
 pub const SVSM_DS_FLAGS: u16 = 0xc93;
 pub const SVSM_TR_FLAGS: u16 = 0x89;
 


### PR DESCRIPTION
This adds basic functionality to handle exceptions by installing an exception handler that runs in ring0 in the context of Trustlet.

- Currently, only #PF and #DF handlers are installed to support copy-on-write.
- In the future, I plan to add a general exception handler (cf. kernel/src/cpu/idt/common.rs) to handle all kinds of exceptions with single monitor call handler
- I confirmed CoW works for simple case within one trustlet. More tests will be added