### PR TITLE
Runtime: channel creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,6 +609,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +853,7 @@ dependencies = [
  "intrusive-collections",
  "libmstpm",
  "log",
+ "num_enum",
  "packit",
  "syscall",
  "test",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -39,6 +39,7 @@ intrusive-collections.workspace = true
 log = { workspace = true, features = ["max_level_info", "release_max_level_info"] }
 packit.workspace = true
 libmstpm = { workspace = true, optional = true }
+num_enum =  { version="0.7.3", default-features = false }
 
 [target."x86_64-unknown-none".dev-dependencies]
 test.workspace = true

--- a/kernel/src/process_manager/call_handler.rs
+++ b/kernel/src/process_manager/call_handler.rs
@@ -12,6 +12,10 @@ const DELETE_ZYGOTE: u32 = 5;
 const CREATE_TRUSTLET: u32 = 6;
 const DELETE_TRUSTLET: u32 = 7;
 const INVOKE_TRUSTLET: u32 = 8; 
+const _WAIT_FOR_TRUSTLET_RESULT: u32 = 9;  // unused but defined in vmpl.h
+const CREATE_CHANNEL: u32 = 10;
+#[allow(dead_code)]
+const DELETE_CHANNEL: u32 = 11;
 
 const GET_PUBLIC_KEY: u32 = 30;
 const SEND_POLICY: u32 = 31;
@@ -63,6 +67,10 @@ fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
     super::super::process_runtime::runtime::invoke_trustlet(params)
 }
 
+fn create_channel(params: &mut RequestParams) -> Result<(), SvsmReqError> {
+    super::super::process_runtime::runtime::create_channel(params)
+}
+
 pub fn monitor_call_handler(request: u32, params: &mut RequestParams) -> Result<(), SvsmReqError> {
     log::info!("request: {}",request);
     match request {
@@ -75,6 +83,7 @@ pub fn monitor_call_handler(request: u32, params: &mut RequestParams) -> Result<
         GET_PUBLIC_KEY => get_public_key(params),
         SEND_POLICY => send_policy(params),
         INVOKE_TRUSTLET => invoke_trustlet(params),
+        CREATE_CHANNEL => create_channel(params),
         _ => Err(SvsmReqError::unsupported_call()),
     }
 }

--- a/kernel/src/process_manager/memory_channels.rs
+++ b/kernel/src/process_manager/memory_channels.rs
@@ -4,8 +4,8 @@ use crate::{address::{PhysAddr, VirtAddr}, cpu::flush_tlb_global, map_paddr, mm:
 
 use super::{allocation::AllocationRange, process::ProcessID, process_paging::ProcessPageTableRef};
 
-pub const INPUT_VADDR: u64 = 0x28000000000u64;
-pub const OUTPUT_VADDR: u64 = 0x30000000000u64;
+pub const INPUT_VADDR: u64 = 0x280_0000_0000u64;
+pub const OUTPUT_VADDR: u64 = 0x300_0000_0000u64;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MemoryChannel {

--- a/kernel/src/process_manager/process.rs
+++ b/kernel/src/process_manager/process.rs
@@ -20,6 +20,7 @@ use crate::process_manager::process_memory::allocate_page;
 use crate::process_manager::allocation::AllocationRange;
 use crate::process_manager::process_paging::ProcessPageTableRef;
 use crate::process_manager::process_paging::ProcessPageFlags;
+use crate::process_runtime::runtime::MmapManager;
 use crate::protocols::errors::SvsmReqError;
 use crate::protocols::RequestParams;
 use crate::sev::RMPFlags;
@@ -80,8 +81,8 @@ impl TrustedProcessStore {
         ptr.push(process);
     }
     pub fn init(&self, size: u32){
-        let empty_process = TrustedProcess::empty();
         for _ in 0..size  {
+            let empty_process = TrustedProcess::empty();
             self.push(empty_process);
         }
     }
@@ -121,7 +122,7 @@ impl ProcessData {
 #[derive(Clone,Copy,Debug, Default)]
 pub struct ProcessID(pub usize);
 
-#[derive(Clone,Copy,Debug)]
+#[derive(Clone,Debug)]
 pub struct TrustedProcess {
     pub process_type: TrustedProcessType,
     pub id: u64,
@@ -130,7 +131,8 @@ pub struct TrustedProcess {
     pub measurements: ProcessMeasurements,
     #[allow(dead_code)]
     pub context: ProcessContext,
-    //pub channel: MemoryChannel,
+    pub mmap_manager: MmapManager,
+    pub pf_target_vaddr: u64,
 }
 
 impl TrustedProcess {
@@ -179,6 +181,8 @@ impl TrustedProcess {
             base,
             measurements,
             context: ProcessContext::default(),
+            mmap_manager: MmapManager::new(),
+            pf_target_vaddr: 0,
         }
     }
 
@@ -196,6 +200,8 @@ impl TrustedProcess {
             base,
             measurements,
             context,
+            mmap_manager: MmapManager::new(),
+            pf_target_vaddr: 0,
         }
 
     }
@@ -226,6 +232,8 @@ impl TrustedProcess {
             base: ProcessBaseContext::default(),
             measurements: ProcessMeasurements::default(),
             context: ProcessContext::default(),
+            mmap_manager: MmapManager::new(),
+            pf_target_vaddr: 0,
         }
     }
 

--- a/kernel/src/process_manager/process.rs
+++ b/kernel/src/process_manager/process.rs
@@ -18,7 +18,7 @@ use crate::mm::pagetable::PageTableRef;
 use crate::mm::SVSM_PERCPU_VMSA_BASE;
 use crate::process_manager::process_memory::allocate_page;
 use crate::process_manager::allocation::AllocationRange;
-use crate::process_manager::process_paging::ProcessPageTableRef;
+use crate::process_manager::process_paging::{ProcessPageTableRef, TP_MANIFEST_START_VADDR};
 use crate::process_manager::process_paging::ProcessPageFlags;
 use crate::process_runtime::runtime::MmapManager;
 use crate::protocols::errors::SvsmReqError;

--- a/kernel/src/process_manager/process_memory.rs
+++ b/kernel/src/process_manager/process_memory.rs
@@ -63,7 +63,7 @@ pub const PUD: usize = 2;
 pub const PMD: usize = 1;
 pub const PTE: usize = 0;
 
-fn addr_to_idx(addr: usize, lvl: usize) -> usize {
+pub fn addr_to_idx(addr: usize, lvl: usize) -> usize {
     (addr >> (lvl * 9 + 12)) & 0x1FF
 }
 

--- a/kernel/src/process_manager/process_paging.rs
+++ b/kernel/src/process_manager/process_paging.rs
@@ -53,6 +53,9 @@ bitflags! {
         const COPY_ON_WRITE =   1 << 9; // Use this field to mark CoW pages
 
         const NO_EXECUTE =      1 << 63;
+
+        // Special value that indicates to use the flag in the existing entry
+        const FLAG_REUSE = 1 << 10;
     }
 }
 
@@ -557,7 +560,14 @@ impl ProcessPageTableRef {
                 ProcessTableLevelMapping::PTE(table_phys, index) => {
                     let (pte_mapping, pte_table) = paddr_as_table!(table_phys);
                     rmp_adjust(pte_mapping.virt_addr(), RMPFlags::VMPL1 | RMPFlags::RWX , PageSize::Regular).unwrap();
-                    pte_table[index].set(addr, flags);
+                    if flags.contains(ProcessPageFlags::FLAG_REUSE){
+                        // Use the same flags as the existing entry (used for lazy page allocation in the mmaped region)
+                        assert!(flags == ProcessPageFlags::FLAG_REUSE);
+                        let orig_flag = pte_table[index].flags();
+                        pte_table[index].set(addr, orig_flag | ProcessPageFlags::PRESENT);
+                    } else {
+                        pte_table[index].set(addr, flags);
+                    }
                     finished = true;
                 },
                 ProcessTableLevelMapping::PMD(table_phys, index) =>  {

--- a/kernel/src/process_runtime/runtime.rs
+++ b/kernel/src/process_runtime/runtime.rs
@@ -17,6 +17,9 @@ use crate::{paddr_as_table, vaddr_as_slice};
 use crate::types::PageSize;
 use crate::sev::RMPFlags;
 use crate::sev::rmp_adjust;
+use crate::mm::phys_to_virt;
+use crate::process_manager::process_memory::{PGD, addr_to_idx}; 
+use crate::process_manager::memory_channels::{INPUT_VADDR, OUTPUT_VADDR};
 use core::arch::asm;
 
 const TRUSTLET_VMPL: u64 = 1;
@@ -277,6 +280,50 @@ pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
         }
     }
     params.rcx = rc.return_value;
+
+    Ok(())
+}
+
+pub fn create_channel(params: &mut RequestParams) -> Result<(), SvsmReqError> {
+    let tid1 = params.rcx;
+    let tid2 = params.rdx;
+
+    log::info!("Creating Channel: tid={} tid={}", tid1, tid2);
+
+    // map tid1's output channel to tid2's input channel
+
+    let trustlet1 = PROCESS_STORE.get(ProcessID(tid1.try_into().unwrap()));
+    let trustlet2 = PROCESS_STORE.get(ProcessID(tid2.try_into().unwrap()));
+
+    let trustlet1_vmsa_paddr = trustlet1.context.vmsa;
+    let trustlet1_vmsa_mapping = PerCPUPageMappingGuard::create_4k(trustlet1_vmsa_paddr).unwrap();
+    let trustlet1_vmsa: &mut VMSA = unsafe { trustlet1_vmsa_mapping.virt_addr().as_mut_ptr::<VMSA>().as_mut().unwrap() };
+    let trustlet1_cr3 = trustlet1_vmsa.cr3;
+    let trustlet1_cr3_mapping = PerCPUPageMappingGuard::create_4k(PhysAddr::from(trustlet1_cr3)).unwrap();
+    let trustlet1_pgd_table = vaddr_as_u64_slice!(trustlet1_cr3_mapping.virt_addr());
+    let trustlet1_output_channel_pgd_idx = addr_to_idx(OUTPUT_VADDR as usize, PGD);
+
+    let trustlet2_vmsa_paddr = trustlet2.context.vmsa;
+    let trustlet2_vmsa_mapping = PerCPUPageMappingGuard::create_4k(trustlet2_vmsa_paddr).unwrap();
+    let trustlet2_vmsa: &mut VMSA = unsafe { trustlet2_vmsa_mapping.virt_addr().as_mut_ptr::<VMSA>().as_mut().unwrap() };
+    let trustlet2_cr3 = trustlet2_vmsa.cr3;
+    let trustlet2_cr3_mapping = PerCPUPageMappingGuard::create_4k(PhysAddr::from(trustlet2_cr3)).unwrap();
+    let trustlet2_pgd_table = vaddr_as_u64_slice!(trustlet2_cr3_mapping.virt_addr());
+    let trustlet2_input_channel_pgd_idx = addr_to_idx(INPUT_VADDR as usize, PGD);
+
+    log::info!("trustlet1_output_channel_pgd_idx: 0x{:x}", trustlet1_output_channel_pgd_idx);
+    log::info!("trustlet2_input_channel_pgd_idx: 0x{:x}", trustlet2_input_channel_pgd_idx);
+
+    // Update trustlet2's pgd entry
+    //  Trustlet1 CR3 -> PGD [OUTPUT_VADDR] -> <PUD A> -> ...
+    //  Trustlet2 CR3 -> PGD [INPUT_VADDR]  -> <PUD B> -> ...
+    // change trustlet2's PGD entry of INPUT_VADDR to point to trustlet1's output channel
+    //  Trustlet2 CR3 -> PGD [INPUT_VADDR]  -> <PUD A> -> ...
+    let target_addr = trustlet1_pgd_table[trustlet1_output_channel_pgd_idx] & !0xFFF;
+    let pgd_entry = trustlet2_pgd_table[trustlet2_input_channel_pgd_idx];
+    trustlet2_pgd_table[trustlet2_input_channel_pgd_idx] = target_addr | (pgd_entry & 0xFFF);
+
+    // TODO: free trustlet2's old input channel pages
 
     Ok(())
 }

--- a/kernel/src/process_runtime/runtime.rs
+++ b/kernel/src/process_runtime/runtime.rs
@@ -319,9 +319,8 @@ pub fn create_channel(params: &mut RequestParams) -> Result<(), SvsmReqError> {
     //  Trustlet2 CR3 -> PGD [INPUT_VADDR]  -> <PUD B> -> ...
     // change trustlet2's PGD entry of INPUT_VADDR to point to trustlet1's output channel
     //  Trustlet2 CR3 -> PGD [INPUT_VADDR]  -> <PUD A> -> ...
-    let target_addr = trustlet1_pgd_table[trustlet1_output_channel_pgd_idx] & !0xFFF;
-    let pgd_entry = trustlet2_pgd_table[trustlet2_input_channel_pgd_idx];
-    trustlet2_pgd_table[trustlet2_input_channel_pgd_idx] = target_addr | (pgd_entry & 0xFFF);
+    let target_entry = trustlet1_pgd_table[trustlet1_output_channel_pgd_idx];
+    trustlet2_pgd_table[trustlet2_input_channel_pgd_idx] = target_entry;
 
     // TODO: free trustlet2's old input channel pages
 

--- a/kernel/src/process_runtime/runtime.rs
+++ b/kernel/src/process_runtime/runtime.rs
@@ -41,6 +41,7 @@ enum TrustletInvocationType {
     NORMAL=0,
     FILEATTR=1,
     OPEN=2,
+    READ=3,
 }
 
 /// Return value to the guest from invokeTrustlet
@@ -52,6 +53,7 @@ enum TrustletReturnType {
     ERROR=2,
     FILEATTR=3,
     OPEN=4,
+    READ=5,
 }
 
 /// Guest request type from the trustlet (PAL)
@@ -60,6 +62,7 @@ enum TrustletReturnType {
 enum PalSvsmGuestRequestType {
     FILEATTR=0,
     OPEN=1,
+    READ=2,
 }
 
 #[derive(Debug)]
@@ -72,6 +75,7 @@ pub struct PALContext {
     result_size: u64,
     guest_page_table: u64,
     invocation_arg_guest_vaddr: u64,
+    invocation_arg_size: usize,
     return_value: u64,
 }
 
@@ -129,7 +133,7 @@ pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
             trustlet.context.channel.inflate_output(vmsa.cr3, result_size as usize);
             trustlet.context.channel.copy_into(function_arg, guest_page_table, function_arg_size as usize);
         }
-        TrustletInvocationType::FILEATTR | TrustletInvocationType::OPEN => {
+        TrustletInvocationType::FILEATTR | TrustletInvocationType::OPEN | TrustletInvocationType::READ => {
             // log::info!("Invoking Trustlet: gueset request: {:?}", invocation_type);
             let mut guest_page_table_ref = ProcessPageTableRef::default();
             guest_page_table_ref.set_external_table(guest_page_table);
@@ -137,7 +141,7 @@ pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
             let (_mapping, arg_mapping) = map_paddr!(arg_page);
             let arg = unsafe { core::slice::from_raw_parts_mut(arg_mapping.as_mut_ptr::<u8>(), invocation_arg_size) };
 
-            // Copy the fileattr data from the guest to the trustlet
+            // Copy the request arg data from the guest to the trustlet
             let data_ptr = vmsa.rcx;
             let mut page_table_ref = ProcessPageTableRef::default();
             page_table_ref.set_external_table(vmsa.cr3);
@@ -161,6 +165,7 @@ pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
             result_size,
             guest_page_table,
             invocation_arg_guest_vaddr,
+            invocation_arg_size,
             return_value: TrustletReturnType::ERROR as u64,
         };
 
@@ -665,78 +670,42 @@ impl ProcessRuntime for PALContext  {
         let request_type: PalSvsmGuestRequestType = self.vmsa.rbx.try_into().unwrap();
         let data_ptr = self.vmsa.rcx;
         let data_size = self.vmsa.rdx as usize;
+        assert!(data_size <= self.invocation_arg_size, "Data size exceeds the invocation arg size");
 
-        match request_type {
+        let page_table = self.vmsa.cr3;
+        let mut page_table_ref = ProcessPageTableRef::default();
+        page_table_ref.set_external_table(page_table);
+
+        // Map user provided arguments
+        // FIXME: for now we assume that the data is within a single page
+        let data_page = page_table_ref.get_page(VirtAddr::from(data_ptr));
+        let offset = (data_ptr & 0xFFF) as usize;
+        let (_mapping, data_mapping) = map_paddr!(data_page);
+        assert!(offset + data_size <= PAGE_SIZE_4K as usize, "Data size exceeds page size");
+        let data = unsafe { core::slice::from_raw_parts(data_mapping.as_ptr::<u8>().wrapping_add(offset), data_size) };
+
+        // copy the path into the guest arg struct
+        let mut guest_page_table_ref = ProcessPageTableRef::default();
+        guest_page_table_ref.set_external_table(self.guest_page_table);
+        let arg_page = guest_page_table_ref.get_page(VirtAddr::from(self.invocation_arg_guest_vaddr));
+        let (_mapping, arg_mapping) = map_paddr!(arg_page);
+        let arg = unsafe { core::slice::from_raw_parts_mut(arg_mapping.as_mut_ptr::<u8>(), self.invocation_arg_size) };
+        for i in 0..data_size {
+            arg[i] = data[i];
+        }
+        
+        self.return_value = match request_type {
             PalSvsmGuestRequestType::FILEATTR => {
-                log::info!(" [Trustlet] Guest Request: FILEATTR");
-                let page_table = self.vmsa.cr3;
-                let mut page_table_ref = ProcessPageTableRef::default();
-                page_table_ref.set_external_table(page_table);
-
-                // Map user provided arguments
-                // FIXME: for now we assume that the data is within a single page
-                let data_page = page_table_ref.get_page(VirtAddr::from(data_ptr));
-                let offset = (data_ptr & 0xFFF) as usize;
-                let (_mapping, data_mapping) = map_paddr!(data_page);
-                assert!(offset + data_size <= PAGE_SIZE_4K as usize, "Data size exceeds page size");
-                let data = unsafe { core::slice::from_raw_parts(data_mapping.as_ptr::<u8>().wrapping_add(offset), data_size) };
-
-                //log::info!(" [Trustlet] Guest Request: FILEATTR: size={}, data={:?}", data_size, data);
-                // struct fileattr {
-                //     char path[256];
-                //     uint64_t size;
-                //     uint32_t mode;
-                // };
-
-                // copy the path into the guest arg struct
-                let mut guest_page_table_ref = ProcessPageTableRef::default();
-                guest_page_table_ref.set_external_table(self.guest_page_table);
-                let arg_page = guest_page_table_ref.get_page(VirtAddr::from(self.invocation_arg_guest_vaddr));
-                let (_mapping, arg_mapping) = map_paddr!(arg_page);
-                let arg = unsafe { core::slice::from_raw_parts_mut(arg_mapping.as_mut_ptr::<u8>(), 256) };
-                for i in 0..256 {
-                    arg[i] = data[i];
-                }
-
-                // Return to the guest to make a request
-                self.return_value = TrustletReturnType::FILEATTR as u64;
-                return false
+                TrustletReturnType::FILEATTR as u64
             }
             PalSvsmGuestRequestType::OPEN => {
-                log::info!(" [Trustlet] Guest Request: OPEN");
-                let page_table = self.vmsa.cr3;
-                let mut page_table_ref = ProcessPageTableRef::default();
-                page_table_ref.set_external_table(page_table);
-
-                // Map user provided arguments
-                // FIXME: for now we assume that the data is within a single page
-                let data_page = page_table_ref.get_page(VirtAddr::from(data_ptr));
-                let offset = (data_ptr & 0xFFF) as usize;
-                let (_mapping, data_mapping) = map_paddr!(data_page);
-                assert!(offset + data_size <= PAGE_SIZE_4K as usize, "Data size exceeds page size");
-                let data = unsafe { core::slice::from_raw_parts(data_mapping.as_ptr::<u8>().wrapping_add(offset), data_size) };
-
-                //log::info!(" [Trustlet] Guest Request: FILEATTR: size={}, data={:?}", data_size, data);
-                // struct fileattr {
-                //     char path[256];
-                //     uint32_t fd;
-                // };
-
-                // copy the path into the guest arg struct
-                let mut guest_page_table_ref = ProcessPageTableRef::default();
-                guest_page_table_ref.set_external_table(self.guest_page_table);
-                let arg_page = guest_page_table_ref.get_page(VirtAddr::from(self.invocation_arg_guest_vaddr));
-                let (_mapping, arg_mapping) = map_paddr!(arg_page);
-                let arg = unsafe { core::slice::from_raw_parts_mut(arg_mapping.as_mut_ptr::<u8>(), 256) };
-                for i in 0..256 {
-                    arg[i] = data[i];
-                }
-
-                // Return to the guest to make a request
-                self.return_value = TrustletReturnType::OPEN as u64;
-                return false
+                TrustletReturnType::OPEN as u64
             }
-        }
+            PalSvsmGuestRequestType::READ => {
+                TrustletReturnType::READ as u64
+            }
+        };
+        false
     }
 
     /// Handle an exception occured in the trustlet

--- a/kernel/src/process_runtime/runtime.rs
+++ b/kernel/src/process_runtime/runtime.rs
@@ -3,6 +3,10 @@ use igvm_defs::PAGE_SIZE_4K;
 use core::ffi::CStr;
 use core::convert::TryInto;
 use core::str;
+use core::ops::Range;
+use core::cmp::Ordering;
+extern crate alloc;
+use alloc::collections::BTreeMap;
 use num_enum::TryFromPrimitive;
 use crate::address::PhysAddr;
 use crate::process_manager::process_paging::{ProcessTableLevelMapping, TP_LIBOS_START_VADDR};
@@ -42,6 +46,7 @@ enum TrustletInvocationType {
     FILEATTR=1,
     OPEN=2,
     READ=3,
+    MMAP=4,
 }
 
 /// Return value to the guest from invokeTrustlet
@@ -54,6 +59,7 @@ enum TrustletReturnType {
     FILEATTR=3,
     OPEN=4,
     READ=5,
+    MMAP=6,
 }
 
 /// Guest request type from the trustlet (PAL)
@@ -63,6 +69,59 @@ enum PalSvsmGuestRequestType {
     FILEATTR=0,
     OPEN=1,
     READ=2,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MmapInfo {
+    fd: i32, // File descriptor
+    offset: usize, // Offset in the file
+    addr: usize, // Start of trustlet's virtual address of the mapping
+    size: usize, // Size of the mapping
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeWrapper(Range<usize>);
+
+impl PartialOrd for RangeWrapper {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other)) // Delegate to the Ord implementation
+    }
+}
+
+impl Ord for RangeWrapper {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Compare ranges by their start first, then by their end
+        // e.g., [1..3] < [2..4] < [2..5] < [3..4]
+        self.0.start.cmp(&other.0.start).then(self.0.end.cmp(&other.0.end))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MmapManager {
+    mappings: BTreeMap<RangeWrapper, MmapInfo>,
+}
+
+impl MmapManager {
+    pub fn new() -> Self {
+        MmapManager {
+            mappings: BTreeMap::new(),
+        }
+    }
+
+    pub fn add_mapping(&mut self, addr: usize, size: usize, fd: i32, offset: usize) {
+        let range = addr..(addr + size);
+        let info = MmapInfo { fd, offset, addr, size};
+        self.mappings.insert(RangeWrapper(range), info);
+    }
+
+    pub fn lookup(&self, addr: usize) -> Option<&MmapInfo> {
+        // Search for the range that contains the address
+        self.mappings
+        .range(..=RangeWrapper(addr..(addr + 1))) // Find all ranges up to the address
+        .rev()                                    // Reverse the iterator to start from the largest range
+        .find(|(range, _)| range.0.contains(&addr)) // Check if the range contains the address
+        .map(|(_, info)| info) // Return the associated MmapInfo
+    }
 }
 
 #[derive(Debug)]
@@ -80,17 +139,12 @@ pub struct PALContext {
 }
 
 pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
-
     log::info!("Invoking Trustlet");
 
     let id = params.rcx;
-    let guest_data = params.r8;
-    let guest_data_size = params.r9;
-    let guest_page_table = params.rdx;
-    let (invoke_data, range) = ProcessPageTableRef::copy_data_from_guest(guest_data, guest_data_size, guest_page_table);
-    let invoke_data_struct = vaddr_as_u64_slice!(invoke_data);
 
-    // The invoke_data struct given from the guest is defined as follows:
+    // Get the invoke_data given from the guest
+    // The structure of the invoke_data is as follows:
     // struct data {
     //    void* ptr;
     //    uint64_t size;
@@ -101,6 +155,11 @@ pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
     //   struct data result;            // invoke_data_struct[3-4]
     //   struct data guest_request_arg; // invoke_data_struct[5-6]
     //}
+    let guest_data = params.r8;
+    let guest_data_size = params.r9;
+    let guest_page_table = params.rdx;
+    let (invoke_data, range) = ProcessPageTableRef::copy_data_from_guest(guest_data, guest_data_size, guest_page_table);
+    let invoke_data_struct = vaddr_as_u64_slice!(invoke_data);
 
     let invocation_type : TrustletInvocationType = invoke_data_struct[0].try_into().unwrap();
 
@@ -132,8 +191,7 @@ pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
             trustlet.context.channel.inflate_input(vmsa.cr3, function_arg_size as usize);
             trustlet.context.channel.inflate_output(vmsa.cr3, result_size as usize);
             trustlet.context.channel.copy_into(function_arg, guest_page_table, function_arg_size as usize);
-        }
-        TrustletInvocationType::FILEATTR | TrustletInvocationType::OPEN | TrustletInvocationType::READ => {
+        } TrustletInvocationType::FILEATTR | TrustletInvocationType::OPEN | TrustletInvocationType::READ => {
             // log::info!("Invoking Trustlet: gueset request: {:?}", invocation_type);
             let mut guest_page_table_ref = ProcessPageTableRef::default();
             guest_page_table_ref.set_external_table(guest_page_table);
@@ -150,9 +208,47 @@ pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
             let (_mapping, data_mapping) = map_paddr!(data_page);
             assert!(offset + invocation_arg_size <= PAGE_SIZE_4K as usize, "Data size exceeds page size");
             let data = unsafe { core::slice::from_raw_parts_mut(data_mapping.as_mut_ptr::<u8>().wrapping_add(offset), invocation_arg_size) };
+            //log::info!("invocation_arg_size: {}", invocation_arg_size);
             for i in 0..invocation_arg_size {
                 data[i] = arg[i];
             }
+        }
+        TrustletInvocationType::MMAP => {
+            // Handle page fault due to the mmap
+            let mut guest_page_table_ref = ProcessPageTableRef::default();
+            guest_page_table_ref.set_external_table(guest_page_table);
+            let arg_page = guest_page_table_ref.get_page(VirtAddr::from(invocation_arg_guest_vaddr));
+            let (_mapping, arg_mapping) = map_paddr!(arg_page);
+            let arg = unsafe { core::slice::from_raw_parts_mut(arg_mapping.as_mut_ptr::<u64>(), 5) };
+
+            // map guest provided buffer that cointains the file content for the faulting mmap
+            // struct mmap_arg {
+            //     uint64_t fd;
+            //     uint64_t offset;
+            //     uint64_t size;
+            //     uint64_t addr_offset;
+            //     uint64_t buf_addr;
+            // }
+            let buf_guest_addr = arg[4];
+            let buf_page = guest_page_table_ref.get_page(VirtAddr::from(buf_guest_addr));
+            let (_mapping, buf_mapping) = map_paddr!(buf_page);
+            let buf = unsafe { core::slice::from_raw_parts_mut(buf_mapping.as_mut_ptr::<u64>(), 512) };
+
+            // allocate new physical page for the trustlet
+            let mut page_table_ref = ProcessPageTableRef::default();
+            page_table_ref.set_external_table(vmsa.cr3);
+            let new_page = allocate_page();
+            let (mapping, new_page_mapped) = paddr_as_slice!(new_page);
+            rmp_adjust(mapping.virt_addr(), RMPFlags::VMPL1 | RMPFlags::RWX , PageSize::Regular).unwrap();
+            // copy data from the guest buffer to the new page
+            for i in 0..512 {
+               new_page_mapped[i] = buf[i];
+            }
+            assert!(trustlet.pf_target_vaddr != 0);
+            let dst = VirtAddr::from(trustlet.pf_target_vaddr);
+            // update trustlet's page table
+            let flags = ProcessPageFlags::FLAG_REUSE;
+            page_table_ref.map_4k_page(dst, new_page, flags);
         }
     }
 
@@ -458,17 +554,12 @@ impl ProcessRuntime for PALContext  {
 
     /// Map a file into the trustlet's memory space
     /// 
-    /// FIXME: For now, this functions only supports mapping the libos file into the specified address.
-    /// (this works because that is the only callee of this function at the moment)
-    /// As the monitor loads the libos file into the predefined address (TP_LIBOS_START_VADDR) at the start,
-    /// this functions copy data from that region and create a new page table entry.
-    /// 
     /// Register arguments:
     /// * rax: monitor call code (0x4FFFFFFB)
     /// * rbx: virtual address to map
     /// * rcx: size of memory to map
     /// * rdx: flags (GraminePalProtFlags)
-    /// * r8: file descriptor (unused)
+    /// * r8: file descriptor
     /// * r9: offset
     /// 
     /// Return:
@@ -496,13 +587,10 @@ impl ProcessRuntime for PALContext  {
         }
         let num_pages = size / 4096;
 
-        let vaddr = VirtAddr::from(addr);
-        let s_vaddr = VirtAddr::from(TP_LIBOS_START_VADDR);
-
         let writable = (flags & GraminePalProtFlags::WRITE.bits()) != 0;
         let executable = (flags & GraminePalProtFlags::EXEC.bits()) != 0;
         let writecopy = (flags & GraminePalProtFlags::WRITECOPY.bits()) != 0;
-        let mut flags = ProcessPageFlags::PRESENT | ProcessPageFlags::USER_ACCESSIBLE | ProcessPageFlags::ACCESSED;
+        let mut flags = ProcessPageFlags::USER_ACCESSIBLE | ProcessPageFlags::ACCESSED;
         if writable {
             flags |= ProcessPageFlags::WRITABLE;
         }
@@ -514,43 +602,81 @@ impl ProcessRuntime for PALContext  {
             flags |= ProcessPageFlags::NO_EXECUTE;
         }
 
-        for i in 0..num_pages {
-            let src = s_vaddr + ((i * PAGE_SIZE_4K) as usize) + (offset as usize);
-            let dst = vaddr + (i * PAGE_SIZE_4K).try_into().unwrap(); 
-            let t = page_table_ref.virt_to_phys(src);
+        let vaddr = VirtAddr::from(addr);
+        let libos_fd = u64::from_ne_bytes((-2i64).to_ne_bytes());
 
-            /*
-            // CoW version
-            // FIXME: this does not work (unknown #PF with non-present page occurs)
-            page_table_ref.map_4k_page(dst, t, flags);
+        if fd == libos_fd {
+            // the monitor loads the libos file into the predefined address (TP_LIBOS_START_VADDR) at the start
+            let s_vaddr = VirtAddr::from(TP_LIBOS_START_VADDR);
 
-            if writecopy {
-                page_table_ref.change_attr(src, true, false, true, true);
-                // TODO: flush trustleet's TLB
-            }
-            // check
-            let t2 = page_table_ref.virt_to_phys(dst);
-            assert!(t == t2, "Address mapping failed");
-            continue;
-            */
+            flags |= ProcessPageFlags::PRESENT;
 
-            // Non-CoW version (copy page content at this point for writecopy)
-            if writecopy {
-                let (_old_mapping, old_page_mapped) = paddr_as_slice!(t);
-                let new_page = allocate_page();
-                let (mapping, new_page_mapped) = paddr_as_slice!(new_page);
-                rmp_adjust(mapping.virt_addr(), RMPFlags::VMPL1 | RMPFlags::RWX , PageSize::Regular).unwrap();
-                for i in 0..512 {
-                   new_page_mapped[i] = old_page_mapped[i];
-                }
-                let flags = flags | ProcessPageFlags::WRITABLE;
-                page_table_ref.map_4k_page(dst, new_page, flags);
-            } else {
+            for i in 0..num_pages {
+                let src = s_vaddr + ((i * PAGE_SIZE_4K) as usize) + (offset as usize);
+                let dst = vaddr + (i * PAGE_SIZE_4K).try_into().unwrap(); 
+                let t = page_table_ref.virt_to_phys(src);
+
+                /*
+                // CoW version
+                // FIXME: this does not work (unknown #PF with non-present page occurs)
                 page_table_ref.map_4k_page(dst, t, flags);
 
+                if writecopy {
+                    page_table_ref.change_attr(src, true, false, true, true);
+                    // TODO: flush trustleet's TLB
+                }
+                // check
                 let t2 = page_table_ref.virt_to_phys(dst);
                 assert!(t == t2, "Address mapping failed");
+                continue;
+                */
+
+                // Non-CoW version (copy page content at this point for writecopy)
+                if writecopy {
+                    let (_old_mapping, old_page_mapped) = paddr_as_slice!(t);
+                    let new_page = allocate_page();
+                    let (mapping, new_page_mapped) = paddr_as_slice!(new_page);
+                    rmp_adjust(mapping.virt_addr(), RMPFlags::VMPL1 | RMPFlags::RWX , PageSize::Regular).unwrap();
+                    for i in 0..512 {
+                       new_page_mapped[i] = old_page_mapped[i];
+                    }
+                    let flags = flags | ProcessPageFlags::WRITABLE;
+                    page_table_ref.map_4k_page(dst, new_page, flags);
+                } else {
+                    page_table_ref.map_4k_page(dst, t, flags);
+
+                    let t2 = page_table_ref.virt_to_phys(dst);
+                    assert!(t == t2, "Address mapping failed");
+                }
             }
+            self.vmsa.rcx = u64::from_ne_bytes((0i64).to_ne_bytes());
+            return true;
+        }
+
+        // Update mmap information
+        let mmap_manger = &mut self.process.mmap_manager;
+        /*
+        // check if the address is already mapped
+        let mmap_info = mmap_manger.lookup(addr as usize);
+        if !mmap_info.is_none() {
+            log::info!("[pal_svsm_map] Address already mapped: {:?}", mmap_info);
+            self.vmsa.rcx = u64::from_ne_bytes((-1i64).to_ne_bytes());
+            return true;
+
+        }
+        */
+        // XXX: apparently overlapping mapping happens, so we allow it
+        // mmap_manager keeps the address range like the following order
+        // example: [1..3] < [2..4] < [2..5] < [3..4]
+        // page fault hander uses mmap infomation whose range contains the faulting address
+        // and priority is given to the latter one in the order
+        mmap_manger.add_mapping(addr as usize, size as usize, fd as i32, offset as usize);
+
+        // Allocate virtul memory address
+        // The actual content is loaded upon #PF
+        for i in 0..num_pages {
+            let dst = vaddr + (i * PAGE_SIZE_4K).try_into().unwrap(); 
+            page_table_ref.map_4k_page(dst, PhysAddr::new(0), flags);
         }
 
         self.vmsa.rcx = u64::from_ne_bytes((0i64).to_ne_bytes());
@@ -711,6 +837,62 @@ impl ProcessRuntime for PALContext  {
     /// Handle an exception occured in the trustlet
     // XXX: Currently this function assumes that the exception is a #PF
     fn handle_exception(&mut self) -> bool {
+        let rip= self.vmsa.rip;
+        let cr2 = self.vmsa.cr2;
+        let error_code = self.vmsa.rbx;
+        const PF_PRESENT: u64 = 1 << 0;
+        const PF_WRITE: u64 = 1 << 1;
+        const PF_USER: u64 = 1 << 2;
+        const PF_RESERVED: u64 = 1 << 3;
+        const PF_INSTRUCTION: u64 = 1 << 4;
+        let mmap_manager = &self.process.mmap_manager;
+        if let Some(mmap_info) = mmap_manager.lookup(cr2 as usize) {
+            log::info!(" [Trustlet] Found file mapping: mmap_info={:?}", mmap_info);
+            if error_code & PF_PRESENT == 0 {
+                // non-presente page
+                log::debug!(" [Trustlet] Page fault: not present page");
+                let target_page_addr = cr2 & !0xFFF;
+                self.process.pf_target_vaddr = target_page_addr;
+                assert!(target_page_addr >= mmap_info.addr as u64);
+                let addr_offset = target_page_addr - mmap_info.addr as u64;
+                assert!(addr_offset % 4096 == 0);
+
+                // guest arg structure:
+                // struct {
+                //   u64 fd;
+                //   u64 offset;
+                //   u64 size;
+                //   u64 addr_offset;
+                // }
+                let mut guest_page_table_ref = ProcessPageTableRef::default();
+                guest_page_table_ref.set_external_table(self.guest_page_table);
+                let arg_page = guest_page_table_ref.get_page(VirtAddr::from(self.invocation_arg_guest_vaddr));
+                let (_mapping, arg_mapping) = map_paddr!(arg_page);
+                let arg = unsafe { core::slice::from_raw_parts_mut(arg_mapping.as_mut_ptr::<u64>(), 4) };
+                arg[0] = mmap_info.fd as u64;
+                arg[1] = mmap_info.offset as u64;
+                arg[2] = mmap_info.size as u64;
+                arg[3] = addr_offset;
+
+                // make a guest request to load the page
+                self.return_value = TrustletReturnType::MMAP as u64;
+                return false;
+            } else if error_code & PF_PRESENT != 0 && error_code & PF_WRITE != 0 {
+                // CoW
+                let mut page_table_ref = ProcessPageTableRef::default();
+                page_table_ref.set_external_table(self.vmsa.cr3);
+                // Handle CoW
+                log::debug!(" [Trustlet] CoW: RIP={:#x}, CR2={:#x}, Error code={:?}", rip, cr2, error_code);
+                let user_access = error_code & PF_USER != 0;
+                let handled = page_table_ref.handle_cow(VirtAddr::from(cr2), user_access);
+                if handled {
+                    log::debug!(" [Trustlet] CoW: handled");
+                    return true;
+                }
+            }
+        }
+
+        // XXX: it should not come here
         // debug
         let efer = self.vmsa.efer;
         let rip = self.vmsa.rip;
@@ -736,27 +918,6 @@ impl ProcessRuntime for PALContext  {
         let (_mapping, stack_mapping) = map_paddr!(stack_base_paddr);
         for i in 0..9 {
             log::info!(" [Trustlet] Stack (rsp+{}): {:#x}", i*8, unsafe{stack_mapping.as_ptr::<u64>().offset((offset + i).try_into().unwrap()).read()});
-        }
-
-        let rip= self.vmsa.rip;
-        let cr2 = self.vmsa.cr2;
-        let error_code = self.vmsa.rbx;
-        const PF_PRESENT: u64 = 1 << 0;
-        const PF_WRITE: u64 = 1 << 1;
-        const PF_USER: u64 = 1 << 2;
-        const PF_RESERVED: u64 = 1 << 3;
-        const PF_INSTRUCTION: u64 = 1 << 4;
-        if (error_code & PF_PRESENT != 0) && (error_code & PF_WRITE != 0) {
-            let mut page_table_ref = ProcessPageTableRef::default();
-            page_table_ref.set_external_table(self.vmsa.cr3);
-            // Handle CoW
-            log::info!(" [Trustlet] CoW: RIP={:#x}, CR2={:#x}, Error code={:?}", rip, cr2, error_code);
-            let user_access = error_code & PF_USER != 0;
-            let handled = page_table_ref.handle_cow(VirtAddr::from(cr2), user_access);
-            if handled {
-                log::info!(" [Trustlet] CoW: handled");
-                return true;
-            }
         }
 
         /*

--- a/kernel/src/process_runtime/runtime.rs
+++ b/kernel/src/process_runtime/runtime.rs
@@ -40,6 +40,7 @@ pub trait ProcessRuntime {
 enum TrustletInvocationType {
     NORMAL=0,
     FILEATTR=1,
+    OPEN=2,
 }
 
 /// Return value to the guest from invokeTrustlet
@@ -50,6 +51,7 @@ enum TrustletReturnType {
     GETRESULT=1,
     ERROR=2,
     FILEATTR=3,
+    OPEN=4,
 }
 
 /// Guest request type from the trustlet (PAL)
@@ -57,6 +59,7 @@ enum TrustletReturnType {
 #[repr(u64)]
 enum PalSvsmGuestRequestType {
     FILEATTR=0,
+    OPEN=1,
 }
 
 #[derive(Debug)]
@@ -126,8 +129,8 @@ pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
             trustlet.context.channel.inflate_output(vmsa.cr3, result_size as usize);
             trustlet.context.channel.copy_into(function_arg, guest_page_table, function_arg_size as usize);
         }
-        TrustletInvocationType::FILEATTR => {
-            // log::info!("Invoking Trustlet: Fileattr");
+        TrustletInvocationType::FILEATTR | TrustletInvocationType::OPEN => {
+            // log::info!("Invoking Trustlet: gueset request: {:?}", invocation_type);
             let mut guest_page_table_ref = ProcessPageTableRef::default();
             guest_page_table_ref.set_external_table(guest_page_table);
             let arg_page = guest_page_table_ref.get_page(VirtAddr::from(invocation_arg_guest_vaddr));
@@ -656,7 +659,8 @@ impl ProcessRuntime for PALContext  {
     /// * rdx: data size
     /// 
     /// Retrun:
-    /// * rcx: 0 on success, -1 on failure
+    /// This function does not return to the trustle but return to the guest.
+    /// The guest will call another invokeTruslet() after completing the request.
     fn pal_svsm_guest_request(&mut self) -> bool {
         let request_type: PalSvsmGuestRequestType = self.vmsa.rbx.try_into().unwrap();
         let data_ptr = self.vmsa.rcx;
@@ -696,6 +700,40 @@ impl ProcessRuntime for PALContext  {
 
                 // Return to the guest to make a request
                 self.return_value = TrustletReturnType::FILEATTR as u64;
+                return false
+            }
+            PalSvsmGuestRequestType::OPEN => {
+                log::info!(" [Trustlet] Guest Request: OPEN");
+                let page_table = self.vmsa.cr3;
+                let mut page_table_ref = ProcessPageTableRef::default();
+                page_table_ref.set_external_table(page_table);
+
+                // Map user provided arguments
+                // FIXME: for now we assume that the data is within a single page
+                let data_page = page_table_ref.get_page(VirtAddr::from(data_ptr));
+                let offset = (data_ptr & 0xFFF) as usize;
+                let (_mapping, data_mapping) = map_paddr!(data_page);
+                assert!(offset + data_size <= PAGE_SIZE_4K as usize, "Data size exceeds page size");
+                let data = unsafe { core::slice::from_raw_parts(data_mapping.as_ptr::<u8>().wrapping_add(offset), data_size) };
+
+                //log::info!(" [Trustlet] Guest Request: FILEATTR: size={}, data={:?}", data_size, data);
+                // struct fileattr {
+                //     char path[256];
+                //     uint32_t fd;
+                // };
+
+                // copy the path into the guest arg struct
+                let mut guest_page_table_ref = ProcessPageTableRef::default();
+                guest_page_table_ref.set_external_table(self.guest_page_table);
+                let arg_page = guest_page_table_ref.get_page(VirtAddr::from(self.invocation_arg_guest_vaddr));
+                let (_mapping, arg_mapping) = map_paddr!(arg_page);
+                let arg = unsafe { core::slice::from_raw_parts_mut(arg_mapping.as_mut_ptr::<u8>(), 256) };
+                for i in 0..256 {
+                    arg[i] = data[i];
+                }
+
+                // Return to the guest to make a request
+                self.return_value = TrustletReturnType::OPEN as u64;
                 return false
             }
         }

--- a/kernel/src/process_runtime/runtime.rs
+++ b/kernel/src/process_runtime/runtime.rs
@@ -1,7 +1,9 @@
 use cpuarch::vmsa::VMSA;
 use igvm_defs::PAGE_SIZE_4K;
 use core::ffi::CStr;
+use core::convert::TryInto;
 use core::str;
+use num_enum::TryFromPrimitive;
 use crate::address::PhysAddr;
 use crate::process_manager::process_paging::{ProcessTableLevelMapping, TP_LIBOS_START_VADDR};
 use crate::{address::VirtAddr, cpu::{cpuid::{cpuid_table_raw, CpuidResult}, percpu::{this_cpu, this_cpu_unsafe}}, map_paddr, mm::{PerCPUPageMappingGuard, PAGE_SIZE}, paddr_as_slice, process_manager::{process::{ProcessID, TrustedProcess, PROCESS_STORE}, process_memory::allocate_page, process_paging::{GraminePalProtFlags, ProcessPageFlags, ProcessPageTableRef}}, protocols::{errors::SvsmReqError, RequestParams}, vaddr_as_u64_slice};
@@ -27,8 +29,34 @@ pub trait ProcessRuntime {
     fn pal_svsm_set_tcb(&mut self) -> bool;
     fn pal_svsm_cpuid(&mut self) -> bool;
     fn pal_svsm_get_result(&mut self) -> bool;
+    fn pal_svsm_guest_request(&mut self) -> bool;
     fn handle_exception(&mut self) -> bool;
     fn handle_df(&mut self) -> bool;
+}
+
+/// Invocation type of invokeTrustlet
+#[derive(Debug,Clone,Copy,Eq,PartialEq,TryFromPrimitive)]
+#[repr(u64)]
+enum TrustletInvocationType {
+    NORMAL=0,
+    FILEATTR=1,
+}
+
+/// Return value to the guest from invokeTrustlet
+#[derive(Debug,Clone,Copy,Eq,PartialEq,TryFromPrimitive)]
+#[repr(u64)]
+enum TrustletReturnType {
+    EXIT=0,
+    GETRESULT=1,
+    ERROR=2,
+    FILEATTR=3,
+}
+
+/// Guest request type from the trustlet (PAL)
+#[derive(Debug,Clone,Copy,Eq,PartialEq,TryFromPrimitive)]
+#[repr(u64)]
+enum PalSvsmGuestRequestType {
+    FILEATTR=0,
 }
 
 #[derive(Debug)]
@@ -40,6 +68,7 @@ pub struct PALContext {
     result_addr: u64,
     result_size: u64,
     guest_page_table: u64,
+    invocation_arg_guest_vaddr: u64,
     return_value: u64,
 }
 
@@ -54,12 +83,28 @@ pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
     let (invoke_data, range) = ProcessPageTableRef::copy_data_from_guest(guest_data, guest_data_size, guest_page_table);
     let invoke_data_struct = vaddr_as_u64_slice!(invoke_data);
 
-    let function_arg = invoke_data_struct[0];
+    // The invoke_data struct given from the guest is defined as follows:
+    // struct data {
+    //    void* ptr;
+    //    uint64_t size;
+    // }
+    // struct invoke_data {
+    //   uint64_t invocation_type;      // invoke_data_struct[0]
+    //   struct data function_arg;      // invoke_data_struct[1-2]
+    //   struct data result;            // invoke_data_struct[3-4]
+    //   struct data guest_request_arg; // invoke_data_struct[5-6]
+    //}
+
+    let invocation_type : TrustletInvocationType = invoke_data_struct[0].try_into().unwrap();
+
+    let function_arg = invoke_data_struct[1];
     let function_arg_size = invoke_data_struct[2];
 
-    let result_addr = invoke_data_struct[1];
-    let result_size = invoke_data_struct[3];
+    let result_addr = invoke_data_struct[3];
+    let result_size = invoke_data_struct[4];
 
+    let invocation_arg_guest_vaddr = invoke_data_struct[5];
+    let invocation_arg_size = invoke_data_struct[6] as usize;
 
     let trustlet = PROCESS_STORE.get(ProcessID(id.try_into().unwrap()));
 
@@ -68,27 +113,53 @@ pub fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
     let vmsa_mapping = PerCPUPageMappingGuard::create_4k(trustlet.context.vmsa).unwrap();
     let vmsa: &mut VMSA = unsafe { vmsa_mapping.virt_addr().as_mut_ptr::<VMSA>().as_mut().unwrap() };
 
-    let apic_id = this_cpu().get_apic_id();
-
     let mut string_buf: [u8;256] = [0;256];
     let mut string_pos: usize = 0;
     let sev_features = trustlet.context.sev_features;
 
-    trustlet.context.channel.inflate_input(vmsa.cr3, function_arg_size as usize);
-    trustlet.context.channel.inflate_output(vmsa.cr3, result_size as usize);
+    let apic_id = this_cpu().get_apic_id();
 
-    trustlet.context.channel.copy_into(function_arg, guest_page_table, function_arg_size as usize);
+    match invocation_type {
+        TrustletInvocationType::NORMAL => {
+            // log::info!("Invoking Trustlet: Normal");
+            trustlet.context.channel.inflate_input(vmsa.cr3, function_arg_size as usize);
+            trustlet.context.channel.inflate_output(vmsa.cr3, result_size as usize);
+            trustlet.context.channel.copy_into(function_arg, guest_page_table, function_arg_size as usize);
+        }
+        TrustletInvocationType::FILEATTR => {
+            // log::info!("Invoking Trustlet: Fileattr");
+            let mut guest_page_table_ref = ProcessPageTableRef::default();
+            guest_page_table_ref.set_external_table(guest_page_table);
+            let arg_page = guest_page_table_ref.get_page(VirtAddr::from(invocation_arg_guest_vaddr));
+            let (_mapping, arg_mapping) = map_paddr!(arg_page);
+            let arg = unsafe { core::slice::from_raw_parts_mut(arg_mapping.as_mut_ptr::<u8>(), invocation_arg_size) };
+
+            // Copy the fileattr data from the guest to the trustlet
+            let data_ptr = vmsa.rcx;
+            let mut page_table_ref = ProcessPageTableRef::default();
+            page_table_ref.set_external_table(vmsa.cr3);
+            let data_page = page_table_ref.get_page(VirtAddr::from(data_ptr));
+            let offset = (data_ptr & 0xFFF) as usize;
+            let (_mapping, data_mapping) = map_paddr!(data_page);
+            assert!(offset + invocation_arg_size <= PAGE_SIZE_4K as usize, "Data size exceeds page size");
+            let data = unsafe { core::slice::from_raw_parts_mut(data_mapping.as_mut_ptr::<u8>().wrapping_add(offset), invocation_arg_size) };
+            for i in 0..invocation_arg_size {
+                data[i] = arg[i];
+            }
+        }
+    }
 
     let mut rc = PALContext{
-        process: trustlet,
-        vmsa,
-        string_buf,
-        string_pos,
-        result_addr,
-        result_size,
-        guest_page_table,
-        return_value: 1,
-    };
+            process: trustlet,
+            vmsa,
+            string_buf,
+            string_pos,
+            result_addr,
+            result_size,
+            guest_page_table,
+            invocation_arg_guest_vaddr,
+            return_value: TrustletReturnType::ERROR as u64,
+        };
 
     // Execution loop of the trustlet
     // Currently the trustlet runs to completion
@@ -155,6 +226,9 @@ impl ProcessRuntime for PALContext  {
             }
             0x4FFFFFF8 => {
                 return self.pal_svsm_get_result();
+            }
+            0x4FFFFFF7 => {
+                return self.pal_svsm_guest_request();
             }
             // monitor calls (other)
             0x4EFFFFFF => {
@@ -236,7 +310,7 @@ impl ProcessRuntime for PALContext  {
             self.result_addr,
             self.guest_page_table,
             self.result_size as usize);
-        self.return_value = 0;
+        self.return_value = TrustletReturnType::GETRESULT as u64;
         false
     }
 
@@ -338,6 +412,7 @@ impl ProcessRuntime for PALContext  {
         // PAL exits, exit the trustlet
         let exit_code = self.vmsa.rbx;
         log::info!(" [Trustlet] Exit with Status Code: {}", exit_code);
+        self.return_value = TrustletReturnType::EXIT as u64;
         false
     }
 
@@ -570,6 +645,60 @@ impl ProcessRuntime for PALContext  {
         log::info!("RDX: {:#x}", rdx);
 
         return true;
+    }
+
+    /// Make a guest request
+    /// 
+    /// Register arguments:
+    /// * rax: monitor call code (0x4FFFFFF7)
+    /// * rbx: request type
+    /// * rcx: additional data (pointer to the trustlet's data)
+    /// * rdx: data size
+    /// 
+    /// Retrun:
+    /// * rcx: 0 on success, -1 on failure
+    fn pal_svsm_guest_request(&mut self) -> bool {
+        let request_type: PalSvsmGuestRequestType = self.vmsa.rbx.try_into().unwrap();
+        let data_ptr = self.vmsa.rcx;
+        let data_size = self.vmsa.rdx as usize;
+
+        match request_type {
+            PalSvsmGuestRequestType::FILEATTR => {
+                log::info!(" [Trustlet] Guest Request: FILEATTR");
+                let page_table = self.vmsa.cr3;
+                let mut page_table_ref = ProcessPageTableRef::default();
+                page_table_ref.set_external_table(page_table);
+
+                // Map user provided arguments
+                // FIXME: for now we assume that the data is within a single page
+                let data_page = page_table_ref.get_page(VirtAddr::from(data_ptr));
+                let offset = (data_ptr & 0xFFF) as usize;
+                let (_mapping, data_mapping) = map_paddr!(data_page);
+                assert!(offset + data_size <= PAGE_SIZE_4K as usize, "Data size exceeds page size");
+                let data = unsafe { core::slice::from_raw_parts(data_mapping.as_ptr::<u8>().wrapping_add(offset), data_size) };
+
+                //log::info!(" [Trustlet] Guest Request: FILEATTR: size={}, data={:?}", data_size, data);
+                // struct fileattr {
+                //     char path[256];
+                //     uint64_t size;
+                //     uint32_t mode;
+                // };
+
+                // copy the path into the guest arg struct
+                let mut guest_page_table_ref = ProcessPageTableRef::default();
+                guest_page_table_ref.set_external_table(self.guest_page_table);
+                let arg_page = guest_page_table_ref.get_page(VirtAddr::from(self.invocation_arg_guest_vaddr));
+                let (_mapping, arg_mapping) = map_paddr!(arg_page);
+                let arg = unsafe { core::slice::from_raw_parts_mut(arg_mapping.as_mut_ptr::<u8>(), 256) };
+                for i in 0..256 {
+                    arg[i] = data[i];
+                }
+
+                // Return to the guest to make a request
+                self.return_value = TrustletReturnType::FILEATTR as u64;
+                return false
+            }
+        }
     }
 
     /// Handle an exception occured in the trustlet


### PR DESCRIPTION
### Summary
Memory channel is created by updating trustlet2's PGD entry for the output so that it points to the trustlet1's PUD entry for the input

Example:
```
<Before creating channel>
- Trustlet1 CR3 -> PGD [OUTPUT_VADDR] -> <PUD A> -> ...
- Trustlet2 CR3 -> PGD [INPUT_VADDR]  -> <PUD B> -> ...
// change trustlet2's PGD entry of INPUT_VADDR to point to trustlet1's output channel
<After creating channel>
- Trustlet2 CR3 -> PGD [INPUT_VADDR]  -> <PUD A> ->
```

### Test
- See `./module/libwallet/test_channel.py`
    - This runs `./module/libwallet/externel/channel_test` (compilation is needed)

### Note
- This is based on https://github.com/TUM-DSE/svsm/pull/10