### PR TITLE
Attestation microbenchmark

### DIFF
--- a/igvmbuilder/src/vmsa.rs
+++ b/igvmbuilder/src/vmsa.rs
@@ -112,7 +112,8 @@ pub fn construct_vmsa(
 
     let mut features = SevFeatures::new();
     features.set_snp(true);
-    features.set_restrict_injection(true);
+    // features.set_restrict_injection(true);
+    features.set_restrict_injection(false);
     if vtom != 0 {
         vmsa.virtual_tom = vtom;
         features.set_vtom(true);

--- a/kernel/src/attestation/monitor.rs
+++ b/kernel/src/attestation/monitor.rs
@@ -19,6 +19,19 @@ use crate::process_manager::process::ProcessID;
 use crate::process_manager::process_paging::ProcessPageTableRef;
 use crate::mm::PAGE_SIZE;
 
+/* crates for attestation microbenchmarks */
+use crate::process_manager::process_paging::{TP_MANIFEST_START_VADDR, TP_LIBOS_START_VADDR, TP_FUNCTION_START_VADDR};
+use crate::address::VirtAddr;
+use cpuarch::vmsa::VMSA;
+use crate::map_paddr;
+use crate::process_manager::process_memory::{allocate_page, ALLOCATION_RANGE_VIRT_START};
+use crate::cpu::control_regs::{read_cr3};
+use crate::address::Address;
+use crate::mm::phys_to_virt;
+use crate::process_manager::process_memory::{PGD, addr_to_idx};
+use crate::cpu::flush_tlb_global;
+/* end of crates for attestation microbenchmarks */
+
 struct StoredSNPReport {
   data: Vec<u8>, // Dynamically sized to hold only the actual report
   size: usize,
@@ -50,6 +63,13 @@ pub const MONITOR_ATTESTATION: u64 = 0;
 const ZYGOTE_ATTESTATION: u64 = 1;
 const TRUSTLET_ATTESTATION: u64 = 2;
 const FUNCTION_ATTESTATION: u64 = 3;
+/* helper attestation options for microbenchmarks */
+pub const MONITOR_ATTESTATION_COLD: u64 = 4;
+const PREPARE_ZYGOTE_ATTESTATION_COLD: u64 = 5;
+const ZYGOTE_ATTESTATION_COLD: u64 = 6;
+const PREPARE_TRUSTLET_ATTESTATION_COLD: u64 = 7;
+const TRUSTLET_ATTESTATION_COLD: u64 = 8;
+/* end of helper attestation options for microbenchmarks */
 
 #[derive(Debug, Copy, Clone)]
 pub struct ProcessMeasurements {
@@ -88,7 +108,7 @@ pub fn measure(start_address: u64, size: u64) -> [u8; HASH_SIZE] {
             hash.as_mut_ptr(),
         );
     }
-
+    log::debug!("[Measure] resulting hash {:?}", hash);
     // Return the final hash measurement
     hash
 }
@@ -336,21 +356,43 @@ fn function_report(params: &mut RequestParams) -> Result<(), SvsmReqError>{
 pub fn diff_attestation(params: &mut RequestParams) -> Result<(), SvsmReqError>{
     match params.rdx {
         MONITOR_ATTESTATION => {
-            log::info!("[Performing monitor attestation]");
+            log::debug!("[Performing monitor attestation]");
             let _ = monitor_report(params);
         }
         ZYGOTE_ATTESTATION => {
-            log::info!("[Performing zygote {} attestation]", params.r8);
+            log::debug!("[Performing zygote {} attestation]", params.r8);
             let _ = zygote_report(params);
         }
         TRUSTLET_ATTESTATION => {
-            log::info!("[Performing trustlet {} attestation]", params.r8);
+            log::debug!("[Performing trustlet {} attestation]", params.r8);
             let _ = trustlet_report(params);
         }
         FUNCTION_ATTESTATION => {
-            log::info!("[Performing function attestation]");
+            log::debug!("[Performing function attestation]");
             let _ = function_report(params);
         }
+        /* helper attestation options for microbenchmarks */
+        MONITOR_ATTESTATION_COLD => {
+            log::debug!("[Performing monitor cold report generation]");
+            let _ = monitor_report_cold(params);
+        }
+        PREPARE_ZYGOTE_ATTESTATION_COLD => {
+            log::debug!("[Preparing zygote {} cold report generation]", params.r8);
+            let _ = prepare_zygote_report_cold(params);
+        }
+        ZYGOTE_ATTESTATION_COLD => {
+            log::debug!("[Performing zygote {} cold report generation]", params.r8);
+            let _ = zygote_report_cold(params);
+        }
+        PREPARE_TRUSTLET_ATTESTATION_COLD => {
+            log::debug!("[Preparing trustlet {} cold report generation]", params.r8);
+            let _ = prepare_trustlet_report_cold(params);
+        }
+        TRUSTLET_ATTESTATION_COLD => {
+            log::debug!("[Performing trustlet {} cold report generation]", params.r8);
+            let _ = trustlet_report_cold(params);
+        }
+        /* end of helper attestation options for microbenchmarks */
         _ => {
             log::info!("[Unknown attestation request type]");
         }
@@ -437,3 +479,209 @@ pub fn send_policy(params: &mut RequestParams) -> Result<(), SvsmReqError> {
                                 sender_pub_key.as_mut_ptr(), (*get_keys()).private_key.as_mut_ptr())};
     Ok(())
 }
+
+/* helper report generation options for attestation microbenchmarks */
+#[allow(non_snake_case)]
+fn monitor_report_cold(params: &mut RequestParams) -> Result<(), SvsmReqError> {
+
+    // The report does not exist so, retrieve and store the Original SNP report
+    log::debug!("Monitor retrieves the SNP report");
+    let mut rep: [u8; REPORT_RESPONSE_SIZE] = [0; REPORT_RESPONSE_SIZE];
+
+    /* Get a regular report of type struct SnpReportResponse */
+    let _rep_struct_size = match get_regular_report(&mut rep) {
+        Ok(e) => e,
+        Err(e) => {
+            log::info!("Error from get report: {:?}", e);
+            panic!();
+        }
+    };
+
+    // Cast the raw bytes into an SnpReportResponse
+    let snp_response: &SnpReportResponse = unsafe {
+      &*(rep.as_ptr() as *const SnpReportResponse)
+    };
+
+    // Check the response for validation
+    match snp_response.validate() {
+      Ok(e) => e,
+      Err(e) => {
+          log::info!("Invalid SNP report: {:?}", e);
+          panic!();
+      }
+    };
+
+    let report_size = snp_response.get_report_size() as usize;
+    let report = snp_response.get_report();
+    log::debug!("actual report size { }", snp_response.get_report_size());
+
+    let report_bytes = unsafe {
+      core::slice::from_raw_parts(
+          (report as *const AttestationReport) as *const u8,
+          report_size,
+      )
+    };
+
+    // Return the report (if requested)
+    if params.rcx != 0 {
+        copy_back_report(params.rcx, report_bytes, report_size);
+    }
+    Ok(())
+}
+
+#[allow(non_snake_case)]
+fn prepare_zygote_report_cold(params: &mut RequestParams) -> Result<(), SvsmReqError>{
+    let zygote_id = ProcessID(params.r8 as usize);
+    let zygote = PROCESS_STORE.get(zygote_id);
+
+    // we need to mount the allocation range for the init to have a valid translation
+    // for the ALLOCATION_RANGE_VIRT_START address
+    zygote.base.alloc_range.mount();
+    let init_ptr = ALLOCATION_RANGE_VIRT_START; //zygote.base.alloc_range.0;
+    let manifest_ptr = TP_MANIFEST_START_VADDR; //zygote.base.alloc_range_manifest.0;
+    let libos_ptr = TP_LIBOS_START_VADDR; //zygote.base.alloc_range_libos.0;
+
+    // Getting the monitor page table ref
+    let monitor_cr3 = read_cr3().bits() as u64;
+    let monitor_cr3_mapping = PerCPUPageMappingGuard::create_4k(PhysAddr::from(monitor_cr3)).unwrap();
+    let monitor_pgd_table = vaddr_as_u64_slice!(monitor_cr3_mapping.virt_addr());
+
+    // Getting the zygote page table ref
+    let zygote_cr3 = zygote.base.page_table_ref.process_page_table;
+    let zygote_cr3_mapping = PerCPUPageMappingGuard::create_4k(PhysAddr::from(zygote_cr3)).unwrap();
+    let zygote_pgd_table = vaddr_as_u64_slice!(zygote_cr3_mapping.virt_addr());
+
+    // Get the page table indices for each entry
+    // let monitor_init_pgd_idx = addr_to_idx(init_ptr as usize, PGD);
+    // let zygote_init_pgd_idx = addr_to_idx(init_ptr as usize, PGD);
+    let monitor_manifest_pgd_idx = addr_to_idx(manifest_ptr as usize, PGD);
+    let zygote_manifest_pgd_idx = addr_to_idx(manifest_ptr as usize, PGD);
+    let monitor_libos_pgd_idx = addr_to_idx(libos_ptr as usize, PGD);
+    let zygote_libos_pgd_idx = addr_to_idx(libos_ptr as usize, PGD);
+
+    // Update monitors's pgd entry
+    // Note that for the init, the monitor's pgd entry is updated through the mount
+    // monitor_pgd_table[monitor_init_pgd_idx] = zygote_pgd_table[zygote_init_pgd_idx];
+    monitor_pgd_table[monitor_manifest_pgd_idx] = zygote_pgd_table[zygote_manifest_pgd_idx];
+    monitor_pgd_table[monitor_libos_pgd_idx] = zygote_pgd_table[zygote_libos_pgd_idx];
+
+    // Flush tlb
+    flush_tlb_global();
+
+    return Ok(());
+}
+
+#[allow(non_snake_case)]
+fn zygote_report_cold(params: &mut RequestParams) -> Result<(), SvsmReqError>{
+    let zygote_id = ProcessID(params.r8 as usize);
+    let zygote = PROCESS_STORE.get(zygote_id);
+
+    let init_ptr = ALLOCATION_RANGE_VIRT_START;//zygote.base.alloc_range.0;
+    let init_size = zygote.base.alloc_range.1;
+    let manifest_ptr = TP_MANIFEST_START_VADDR;//zygote.base.alloc_range_manifest.0;
+    let manifest_size = zygote.base.alloc_range_manifest.1;
+    let libos_ptr = TP_LIBOS_START_VADDR;//zygote.base.alloc_range_libos.0;
+    let libos_size = zygote.base.alloc_range_libos.1;
+
+    // calculate the measurements
+    let manifest_measurement = measure(manifest_ptr.into(), manifest_size);
+    let libos_measurement = measure(libos_ptr.into(), libos_size);
+    let init_measurement = measure(init_ptr.into(), init_size);
+    let function_measurement = zygote.measurements.function_measurement;
+
+    // Construct the new report
+    let mut new_report: Vec<u8> = Vec::new();
+
+    if let Some((existing_report, _existing_report_size)) = get_snp_report() {
+        // Copy the existing report data into the new report
+        new_report.extend_from_slice(existing_report);
+    }
+    else {
+        log::info!("SNP report is missing");
+        panic!();
+    }
+
+    // Append the measurements to the new report
+    new_report.extend_from_slice(&init_measurement);
+    new_report.extend_from_slice(&manifest_measurement);
+    new_report.extend_from_slice(&libos_measurement);
+    new_report.extend_from_slice(&function_measurement);
+
+    // Now new_report holds the existing report data + measurements
+    let new_report_size = new_report.len();
+
+    // Perform the copy_back_report with the new cumulative report
+    if params.rcx != 0 {
+        copy_back_report(params.rcx, &new_report, new_report_size);
+    }
+    zygote.base.alloc_range.unmount();
+    return Ok(());
+}
+
+#[allow(non_snake_case)]
+fn prepare_trustlet_report_cold(params: &mut RequestParams) -> Result<(), SvsmReqError>{
+    let trustlet_id = ProcessID(params.r8 as usize);
+    let trustlet = PROCESS_STORE.get(trustlet_id);
+
+    let function_ptr = TP_FUNCTION_START_VADDR;
+
+    // Getting the monitor page table ref
+    let monitor_cr3 = read_cr3().bits() as u64;
+    let monitor_cr3_mapping = PerCPUPageMappingGuard::create_4k(PhysAddr::from(monitor_cr3)).unwrap();
+    let monitor_pgd_table = vaddr_as_u64_slice!(monitor_cr3_mapping.virt_addr());
+
+    // Getting the trustlet page table ref
+    let trustlet_cr3 = trustlet.context.page_table_ref.process_page_table;
+    let trustlet_cr3_mapping = PerCPUPageMappingGuard::create_4k(PhysAddr::from(trustlet_cr3)).unwrap();
+    let trustlet_pgd_table = vaddr_as_u64_slice!(trustlet_cr3_mapping.virt_addr());
+
+    let monitor_function_pgd_idx = addr_to_idx(function_ptr as usize, PGD);
+    let trustlet_function_pgd_idx = addr_to_idx(function_ptr as usize, PGD);
+
+    monitor_pgd_table[monitor_function_pgd_idx] = trustlet_pgd_table[trustlet_function_pgd_idx];
+
+    return Ok(());
+}
+
+#[allow(non_snake_case)]
+fn trustlet_report_cold(params: &mut RequestParams) -> Result<(), SvsmReqError>{
+    let trustlet_id = ProcessID(params.r8 as usize);
+    let trustlet = PROCESS_STORE.get(trustlet_id);
+
+    let function_ptr = TP_FUNCTION_START_VADDR;
+    let function_size = trustlet.base.alloc_range_function.1;
+
+    let init_measurement = trustlet.measurements.init_measurement;
+    let manifest_measurement = trustlet.measurements.manifest_measurement;
+    let libos_measurement = trustlet.measurements.libos_measurement;
+    let function_measurement = measure(function_ptr.into(), function_size);
+
+    // Construct the new report
+    let mut new_report: Vec<u8> = Vec::new();
+
+    if let Some((existing_report, _existing_report_size)) = get_snp_report() {
+        // Copy the existing report data into the new report
+        new_report.extend_from_slice(existing_report);
+    }
+    else {
+        log::info!("SNP report is missing");
+        panic!();
+    }
+
+    // Append the measurements to the new report
+    new_report.extend_from_slice(&init_measurement);
+    new_report.extend_from_slice(&manifest_measurement);
+    new_report.extend_from_slice(&libos_measurement);
+    new_report.extend_from_slice(&function_measurement);
+
+    // Now new_report holds the existing report data + measurements
+    let new_report_size = new_report.len();
+
+    // Perform the copy_back_report with the new cumulative report
+    if params.rcx != 0 {
+        copy_back_report(params.rcx, &new_report, new_report_size);
+    }
+
+    return Ok(());
+}
+/* end of helper report generation options for attestation microbenchmarks */

--- a/kernel/src/process_manager/call_handler.rs
+++ b/kernel/src/process_manager/call_handler.rs
@@ -36,7 +36,7 @@ fn monitor_init(params: &mut RequestParams) -> Result<(), SvsmReqError>{
 }
 
 fn create_zygote(params: &mut RequestParams) -> Result<(), SvsmReqError>{
-    super::process::create_trusted_process(params,TrustedProcessType::Zygote)
+    super::process::create_trusted_process(params, TrustedProcessType::Zygote)
 }
 
 fn delete_zygote(params: &mut RequestParams) -> Result<(), SvsmReqError> {
@@ -64,7 +64,7 @@ fn invoke_trustlet(params: &mut RequestParams) -> Result<(), SvsmReqError> {
 }
 
 pub fn monitor_call_handler(request: u32, params: &mut RequestParams) -> Result<(), SvsmReqError> {
-    log::info!("request: {}",request);
+    log::debug!("request: {}",request);
     match request {
         MONITOR_INIT => monitor_init(params),
         DIFF_ATTEST => diff_attestation(params),

--- a/kernel/src/process_manager/process.rs
+++ b/kernel/src/process_manager/process.rs
@@ -37,6 +37,7 @@ use cpuarch::vmsa::VMSA;
 use core::mem::replace;
 
 use super::process_paging::{TP_STACK_START_VADDR,TP_KERN_STACK_START_VADDR};
+use super::process_paging::{TP_LIBOS_START_VADDR,TP_MANIFEST_START_VADDR};
 use super::memory_channels::MemoryChannel;
 use crate::attestation::monitor::{ProcessMeasurements, measure};
 
@@ -157,18 +158,24 @@ impl TrustedProcess {
         let mut measurements = ProcessMeasurements::default();
 
         let (pal_data, pal_range) = ProcessPageTableRef::copy_data_from_guest(pal, pal_size, pgt);
+        log::debug!("pal_data {:?} pal_range {:?}", pal_data, pal_range);
         base.init_with_data(pal_data, pal_size, pal_range);
         measurements.init_measurement = measure(pal_data.into(), pal_size);
+        pal_range.unmount();
         log::debug!("TODO: Compare with pal measurement of the policy");
 
         let (manifest_data, manifest_range) = ProcessPageTableRef::copy_data_from_guest(manifest, manifest_size, pgt);
+        log::debug!("manifest_range {:?}", manifest_range);
         base.add_manifest(manifest_data, manifest_size, manifest_range);
         measurements.manifest_measurement = measure(manifest_data.into(), manifest_size);
+        manifest_range.unmount();
         log::debug!("TODO: Compare with manifest measurement of the policy");
 
         let (libos_data, libos_range) = ProcessPageTableRef::copy_data_from_guest(libos, libos_size, pgt);
+        log::debug!("libos_range {:?}", libos_range);
         base.add_libos(libos_data, libos_size, libos_range);
         measurements.libos_measurement = measure(libos_data.into(), libos_size);
+        libos_range.unmount();
         log::debug!("TODO: Compare with libos measurement of the policy");
 
         // TODO: Free zygote data
@@ -205,6 +212,8 @@ impl TrustedProcess {
         let mut trustlet = TrustedProcess::dublicate(parent);
         if data != 0 {
             let (function_code, function_code_range) = ProcessPageTableRef::copy_data_from_guest(data, size, pgt);
+            trustlet.base.alloc_range_function.0 = function_code_range.0;
+            trustlet.base.alloc_range_function.1 = size;
 
             log::debug!("Measuring trustlet function");
             trustlet.measurements.function_measurement = measure(function_code.into(), size);
@@ -213,7 +222,7 @@ impl TrustedProcess {
             log::debug!("Adding trustlet function");
             let size = (4096 - (size & 0xFFF)) + size;
             trustlet.context.page_table_ref.add_function(function_code, size);
-            function_code_range.delete();
+            // function_code_range.delete();
         }
         trustlet
     }
@@ -251,7 +260,7 @@ pub fn create_trusted_process(params: &mut RequestParams, t: TrustedProcessType)
         TrustedProcessType::Undefined => panic!("Invalid Creation Request"),
         TrustedProcessType::Zygote => {
 
-            log::info!("create_trusted_process(): Creating and registering Zygote");
+            log::debug!("create_trusted_process(): Creating and registering Zygote");
 
             // Create contexts for the Zygote
             // e.g. Copy the Zygote into memory
@@ -269,12 +278,12 @@ pub fn create_trusted_process(params: &mut RequestParams, t: TrustedProcessType)
             // is not
             params.rcx = u64::from_ne_bytes(res.to_ne_bytes());
            
-            log::info!("Created Zygote #{}", params.rcx);
+            log::debug!("Created Zygote #{}", params.rcx);
             Ok(())
         },
         TrustedProcessType::Trustlet => {
 
-            log::info!("create_trusted_process(): Creating and registering Trustlet");
+            log::debug!("create_trusted_process(): Creating and registering Trustlet");
 
             // We get the Zygote ID from the guest
             // Each Trustlet requires one Zygote
@@ -344,6 +353,7 @@ pub struct ProcessBaseContext {
     pub alloc_range: AllocationRange,
     pub alloc_range_manifest: AllocationRange,
     pub alloc_range_libos: AllocationRange,
+    pub alloc_range_function: AllocationRange,
 }
 
 impl Default for ProcessBaseContext {
@@ -354,6 +364,7 @@ impl Default for ProcessBaseContext {
           alloc_range: AllocationRange(0,0),
           alloc_range_manifest: AllocationRange(0,0),
           alloc_range_libos: AllocationRange(0,0),
+          alloc_range_function: AllocationRange(0,0),
       }
   }
 }
@@ -366,20 +377,25 @@ impl ProcessBaseContext {
     }
 
     pub fn add_manifest(&mut self, manifest: VirtAddr, size: u64, data: AllocationRange) {
+        let orig_size = size;
         let size = (4096 - (size & 0xFFF)) + size;
         self.page_table_ref.add_manifest(manifest, size);
-        self.alloc_range_manifest = data;
+        self.alloc_range_manifest.0 = data.0;
+        self.alloc_range_manifest.1 = orig_size;
     }
 
     pub fn add_libos(&mut self, libos: VirtAddr, size: u64, data: AllocationRange){
+        let orig_size = size;
         let size = (4096 - (size & 0xFFF)) + size;
         self.page_table_ref.add_libos(libos,size);
-        self.alloc_range_libos = data;
+        self.alloc_range_libos.0 = data.0;
+        self.alloc_range_libos.1 = orig_size;
     }
 
     pub fn init_with_data(&mut self, elf: VirtAddr, size: u64, data: AllocationRange) {
         self.init(elf, size);
-        self.alloc_range = data;
+        self.alloc_range.0 = data.0;
+        self.alloc_range.1 = size;
     }
 
 }
@@ -559,9 +575,9 @@ impl ProcessContext {
         // FIXME: propery setup the page flags for the handler
         vmsa.cr4 = vmsa.cr4 & !(1u64 << 20 | 1u64 << 21);
 
-        log::info!("asm_entry_trustlet_pf: {:x}", asm_entry_trustlet_pf as u64);
-        log::info!("asm_entry_trustlet_df: {:x}", asm_entry_trustlet_df as u64);
-        log::info!("gdt_desc: {:x}", unsafe { &gdt_desc as *const u8 as u64 });
+        log::debug!("asm_entry_trustlet_pf: {:x}", asm_entry_trustlet_pf as u64);
+        log::debug!("asm_entry_trustlet_df: {:x}", asm_entry_trustlet_df as u64);
+        log::debug!("gdt_desc: {:x}", unsafe { &gdt_desc as *const u8 as u64 });
 
         // setup IDT
         // 1. setup IDT entry for #PF, #DF
@@ -637,7 +653,7 @@ impl ProcessContext {
             gdt_trustlet_mut().set_tss_entry(desc0, desc1);
         }
         let (base_gdt, limit) = gdt_trustlet().base_limit();
-        log::info!("GDT base: {:x}, limit: {:x}", base_gdt, limit);
+        log::debug!("GDT base: {:x}, limit: {:x}", base_gdt, limit);
         // 1. rmpadjust for GDT
         rmp_adjust(base_gdt.into(), RMPFlags::VMPL1 | RMPFlags::RWX, PageSize::Regular).unwrap();
         // 2. map GDT to trustlet's page table
@@ -677,22 +693,22 @@ impl ProcessContext {
         let efer = vmsa.efer;
         let cr4 = vmsa.cr4;
         let rflags = vmsa.rflags;
-        log::info!("vmsa EFER: {:?}", efer);
-        log::info!("vmsa cr4: {:?}", cr4);
-        log::info!("vmsa CS: {:?}", vmsa.cs);
-        log::info!("vmsa SS: {:?}", vmsa.ss);
-        log::info!("vmsa DS: {:?}", vmsa.ds);
-        log::info!("vmsa rflags: {:?}", rflags);
+        log::debug!("vmsa EFER: {:?}", efer);
+        log::debug!("vmsa cr4: {:?}", cr4);
+        log::debug!("vmsa CS: {:?}", vmsa.cs);
+        log::debug!("vmsa SS: {:?}", vmsa.ss);
+        log::debug!("vmsa DS: {:?}", vmsa.ds);
+        log::debug!("vmsa rflags: {:?}", rflags);
 
         // ------ end of exception handlers setup
 
         //Check VMSA
         let svme_mask: u64 = 1u64 << 12;
         if !check_vmsa_ind(vmsa, vmsa.sev_features, svme_mask, RMPFlags::VMPL1.bits()) {
-            log::info!("VMSA Check failed");
-            log::info!("Bits: {}",vmsa.vmpl == RMPFlags::VMPL1.bits() as u8);
-            log::info!("Efer & vsme_mask: {}", vmsa.efer & svme_mask == svme_mask);
-            log::info!("SEV features: {}", vmsa.sev_features == vmsa.sev_features);
+            log::debug!("VMSA Check failed");
+            log::debug!("Bits: {}",vmsa.vmpl == RMPFlags::VMPL1.bits() as u8);
+            log::debug!("Efer & vsme_mask: {}", vmsa.efer & svme_mask == svme_mask);
+            log::debug!("SEV features: {}", vmsa.sev_features == vmsa.sev_features);
             panic!("Failed to create new VMSA");
         }
 

--- a/kernel/src/process_manager/process_memory.rs
+++ b/kernel/src/process_manager/process_memory.rs
@@ -63,7 +63,7 @@ pub const PUD: usize = 2;
 pub const PMD: usize = 1;
 pub const PTE: usize = 0;
 
-fn addr_to_idx(addr: usize, lvl: usize) -> usize {
+pub fn addr_to_idx(addr: usize, lvl: usize) -> usize {
     (addr >> (lvl * 9 + 12)) & 0x1FF
 }
 

--- a/kernel/src/process_manager/process_paging.rs
+++ b/kernel/src/process_manager/process_paging.rs
@@ -20,6 +20,7 @@ pub const TP_STACK_START_VADDR: u64 = 0x80_0000_0000;
 pub const TP_KERN_STACK_START_VADDR: u64 = 0x90_0000_0000;
 pub const TP_MANIFEST_START_VADDR: u64 = 0x100_0000_0000;
 pub const TP_LIBOS_START_VADDR: u64 = 0x180_0000_0000;
+pub const TP_FUNCTION_START_VADDR: u64 = 0x140_0000_0000;
 
 // Gramine PAL protection flags (pal_prot_flags_t)
 bitflags! {
@@ -270,9 +271,6 @@ impl ProcessPageTableRef {
             let target_addr = vaddr + i * PAGE_SIZE_4K;
             self.map_4k_page(VirtAddr::from(target_addr), new_page, page_flags);
         }
-
-
-
     }
 
     fn build_from_elf(&self, _elf_addr: *mut u8, elf_file: &[u8], elf: elf::Elf64File<'static>) -> VirtAddr{
@@ -308,7 +306,7 @@ impl ProcessPageTableRef {
     pub fn add_function(&self, data:VirtAddr, size: u64) {
         let data: *mut u8 = data.as_mut_ptr::<u8>();
         let data = unsafe { slice::from_raw_parts(data, size as usize) };
-        self.add_region_vaddr(VirtAddr::from(0x140_0000_0000u64), data);
+        self.add_region_vaddr(VirtAddr::from(TP_FUNCTION_START_VADDR), data);
     }
 
     pub fn add_pages(&self, start: VirtAddr, size: u64, flags: ProcessPageFlags) {
@@ -337,7 +335,7 @@ impl ProcessPageTableRef {
         let elf_addr: *mut u8 = data.as_mut_ptr::<u8>();
         let elf_raw = unsafe { slice::from_raw_parts(elf_addr, size as usize) };
         match elf::Elf64File::read(elf_raw) {
-            Ok(e) => self.build_from_elf(elf_addr,elf_raw, e),
+            Ok(e) => self.build_from_elf(elf_addr, elf_raw, e),
             Err(e) => {log::info!("error reading ELF: {}", e);
                        panic!()},
         }


### PR DESCRIPTION
# Attestation microbenchmark

This PR introduces the attestation report generation microbenchmark.
It retrieves measurements and generates reports for zygotes and trustlets independently

Precisely, it performs the following:
- convert some `info` prints to `debug` to not affect the measurements
- set the `AllocationRange` of the `Manifest`, `Libos` and `PAL` correctly
- add an `AllocationRange` in the base context for the `function`
- `AllocationRange`s in the base context now hold their actual size instead of the amount of pages they span to have accurate, correct measurements
- make `addr_to_idx` a public function as it is needed for identifying the mapped regions in the attestation report generation microbenchmark
- add a `TP_FUNCTION_START_VADDR` global variable for the predefined virtual address of the function mapping
- set the `features.set_restrict_injection` to `false` in the `igvmbuilder` to get correct and comparable measurements in the CVM reports
- add helper functions and helper options in the `attest` call in `attestation/monitor.rs` for getting the measurements independently